### PR TITLE
Finetuning a pretrained dinov3 backbone using dinov3

### DIFF
--- a/dinov3/train/ssl_meta_arch.py
+++ b/dinov3/train/ssl_meta_arch.py
@@ -328,6 +328,7 @@ class SSLMetaArch(nn.Module):
                 self.cfg.student.resume_from_teacher_chkpt,
                 skip_load_prefixes=["dino_loss.center", "ibot_patch_loss.center"],
                 prefixes_not_sharded=["backbone.rope_embed.periods"],
+                suffixes_not_sharded=['qkv.bias_mask'],
                 process_group=distributed.get_process_subgroup(),
             )
             self.model_ema.load_state_dict(self.student.state_dict())

--- a/tools/create_dinov3_checkpoint_from_backbone_weights.py
+++ b/tools/create_dinov3_checkpoint_from_backbone_weights.py
@@ -1,0 +1,19 @@
+from argparse import ArgumentParser
+import torch 
+
+
+parser = ArgumentParser()
+parser.add_argument('weights_path', help='Path to the weights of the pretrained backbone')
+parser.add_argument('output_path', help='Path to save the output checkpoint file (optional)', required=False, default=None)
+
+args = parser.parse_args()
+args.output_path = args.output_path or args.weights_path.replace('.pth', '_dinov3_checkpoint.pth')
+
+sd = torch.load(args.weights_path)
+sd = {
+    f'backbone.{key}': val for key, val in sd.items()
+}
+sd = {
+    "teacher": sd
+}
+torch.save(sd, args.output_path)


### PR DESCRIPTION
My goal is to finetune a pretrained dinov3 model using the dinov3 algorithm. 

Some code changes were necessary to make this work:
1. It was necessary to play with the `state_dict` of the pretrained weights so that it matches the format expected by the training code (e.g., needs to have a "teacher" key and "backbone" prefix). I wrote a small script to do that. 
2. There were some `state_dict` buffers which were being sharded even though they shouldn't be (in the `dinov3_vitl16` model, keys that ended with `qkv.bias_mask`). I added a `suffixes_not_sharded` parameter in `init_fsdp_model_from_checkpoint` which handled the issue. 

With these fixes I was able to run dinov3 finetuning using the `dinov3/configs/train/vitl_im1k_lin834.yaml` with `student.resume_from_teacher_chkpt=/path/to/checkpioint`.