### PR TITLE
fix: unify parameter naming for segmentor weights

### DIFF
--- a/dinov3/hub/segmentors.py
+++ b/dinov3/hub/segmentors.py
@@ -76,7 +76,7 @@ def dinov3_vit7b16_ms(
     return _make_dinov3_m2f_segmentor(
         backbone_name="dinov3_vit7b16",
         pretrained=pretrained,
-        weights=weights,
+        segmentor_weights=weights,
         backbone_weights=backbone_weights,
         check_hash=check_hash,
         autocast_dtype=autocast_dtype,


### PR DESCRIPTION
The public API function `dinov3_vit7b16_ms` currently uses the argument name `weights`, while the internal factory `_make_dinov3_m2f_segmentor` uses `segmentor_weights`.

This mismatch causes confusion: when calling `_make_dinov3_m2f_segmentor` via `dinov3_vit7b16_ms`, the `weights` argument is passed through `**kwargs` instead of directly binding to `segmentor_weights`.

As a result, providing a local path string for `weights` does not get properly recognized, since it never overrides the default `segmentor_weights` argument.

Changes:
- Renamed the parameter to consistently use `segmentor_weights` in both the public and internal functions.
- Updated the call site so arguments are passed explicitly and type-checked as expected.