### PR TITLE
Fix bug in ssl_meta_arch.py

### DIFF
--- a/dinov3/train/ssl_meta_arch.py
+++ b/dinov3/train/ssl_meta_arch.py
@@ -482,7 +482,8 @@ class SSLMetaArch(nn.Module):
 
             with torch.no_grad():
                 backbone_out = self.gram_teacher.backbone(images, is_training=True)
-            teacher_patches = backbone_out.x_norm_patchtokens  # [n_crops * B, P_T, D]
+            # teacher_patches = backbone_out.x_norm_patchtokens  # [n_crops * B, P_T, D]
+            teacher_patches = backbone_out["x_norm_patchtokens"]  # [n_crops * B, P_T, D]
 
             # Downsample Gram teacher features if needed
             if teacher_patches.shape[1] != student_patches.shape[1]:


### PR DESCRIPTION
In ssl_meta_arch.py line 485

backbone_out should be a dict, so here should be backbone_out["x_norm_patchtokens"] And not the backbone_out.x_norm_patchtokens .

When I train my dino3 model in gram step, bug show this:

line 398, in forward_backward
gram_global = self.get_gram_teacher_output(
line 485, in get_gram_teacher_output
teacher_patches = backbone_out.x_norm_patchtokens  # [n_crops * B, P_T, D]
 AttributeError: 'dict' object has no attribute 'x_norm_patchtokens'