### PR TITLE
Update torchvision transforms to v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,13 +245,13 @@ from torchvision.transforms import v2
 
 def make_transform(resize_size: int = 224):
     to_tensor = v2.ToImage()
-    resize = v2.Resize((resize_size, resize_size), antialias=True)
     to_float = v2.ToDtype(torch.float32, scale=True)
+    resize = v2.Resize((resize_size, resize_size), antialias=True)
     normalize = v2.Normalize(
         mean=(0.485, 0.456, 0.406),
         std=(0.229, 0.224, 0.225),
     )
-    return v2.Compose([to_tensor, resize, to_float, normalize])
+    return v2.Compose([to_tensor, to_float, resize, normalize])
 ```
 
 
@@ -264,13 +264,13 @@ from torchvision.transforms import v2
 
 def make_transform(resize_size: int = 224):
     to_tensor = v2.ToImage()
-    resize = v2.Resize((resize_size, resize_size), antialias=True)
     to_float = v2.ToDtype(torch.float32, scale=True)
+    resize = v2.Resize((resize_size, resize_size), antialias=True)
     normalize = v2.Normalize(
         mean=(0.430, 0.411, 0.296),
         std=(0.213, 0.156, 0.143),
     )
-    return v2.Compose([to_tensor, resize, to_float, normalize])
+    return v2.Compose([to_tensor, to_float, resize, normalize])
 ```
 
 ### Pretrained heads - Image classification
@@ -348,13 +348,13 @@ def get_img():
 
 def make_transform(resize_size: int | list[int] = 768):
     to_tensor = v2.ToImage()
-    resize = v2.Resize((resize_size, resize_size), antialias=True)
     to_float = v2.ToDtype(torch.float32, scale=True)
+    resize = v2.Resize((resize_size, resize_size), antialias=True)
     normalize = v2.Normalize(
         mean=(0.485, 0.456, 0.406),
         std=(0.229, 0.224, 0.225),
     )
-    return v2.Compose([to_tensor, resize, to_float, normalize])
+    return v2.Compose([to_tensor, to_float, resize, normalize])
 
 depther = torch.hub.load(REPO_DIR, 'dinov3_vit7b16_dd', source="local", weights=<DEPTHER/CHECKPOINT/URL/OR/PATH>, backbone_weights=<BACKBONE/CHECKPOINT/URL/OR/PATH>)
 
@@ -451,13 +451,13 @@ def get_img():
 
 def make_transform(resize_size: int | list[int] = 768):
     to_tensor = v2.ToImage()
-    resize = v2.Resize((resize_size, resize_size), antialias=True)
     to_float = v2.ToDtype(torch.float32, scale=True)
+    resize = v2.Resize((resize_size, resize_size), antialias=True)
     normalize = v2.Normalize(
         mean=(0.485, 0.456, 0.406),
         std=(0.229, 0.224, 0.225),
     )
-    return v2.Compose([to_tensor, resize, to_float, normalize])
+    return v2.Compose([to_tensor, to_float, resize, normalize])
 
 segmentor = torch.hub.load(REPO_DIR, 'dinov3_vit7b16_ms', source="local", weights=<SEGMENTOR/CHECKPOINT/URL/OR/PATH>, backbone_weights=<BACKBONE/CHECKPOINT/URL/OR/PATH>)
 

--- a/README.md
+++ b/README.md
@@ -241,15 +241,17 @@ For models using the LVD-1689M weights (pretrained on web images), please use th
 
 ```python
 import torchvision
+from torchvision.transforms import v2
 
 def make_transform(resize_size: int = 224):
-    to_tensor = transforms.ToTensor()
-    resize = transforms.Resize((resize_size, resize_size), antialias=True)
-    normalize = transforms.Normalize(
+    to_tensor = v2.ToImage()
+    resize = v2.Resize((resize_size, resize_size), antialias=True)
+    to_float = v2.ToDtype(torch.float32, scale=True)
+    normalize = v2.Normalize(
         mean=(0.485, 0.456, 0.406),
         std=(0.229, 0.224, 0.225),
     )
-    return transforms.Compose([to_tensor, resize, normalize])
+    return v2.Compose([to_tensor, resize, to_float, normalize])
 ```
 
 
@@ -258,15 +260,17 @@ For models using the SAT-493M weights (pretrained on satellite imagery), please 
 
 ```python
 import torchvision
+from torchvision.transforms import v2
 
 def make_transform(resize_size: int = 224):
-    to_tensor = transforms.ToTensor()
-    resize = transforms.Resize((resize_size, resize_size), antialias=True)
-    normalize = transforms.Normalize(
+    to_tensor = v2.ToImage()
+    resize = v2.Resize((resize_size, resize_size), antialias=True)
+    to_float = v2.ToDtype(torch.float32, scale=True)
+    normalize = v2.Normalize(
         mean=(0.430, 0.411, 0.296),
         std=(0.213, 0.156, 0.143),
     )
-    return transforms.Compose([to_tensor, resize, normalize])
+    return v2.Compose([to_tensor, resize, to_float, normalize])
 ```
 
 ### Pretrained heads - Image classification
@@ -332,7 +336,7 @@ Full example code of depther on an image
 ```python
 from PIL import Image
 import torch
-from torchvision import transforms
+from torchvision.transforms import v2
 import matplotlib.pyplot as plt
 from matplotlib import colormaps
 
@@ -343,13 +347,14 @@ def get_img():
     return image
 
 def make_transform(resize_size: int | list[int] = 768):
-    to_tensor = transforms.ToTensor()
-    resize = transforms.Resize((resize_size, resize_size), antialias=True)
-    normalize = transforms.Normalize(
+    to_tensor = v2.ToImage()
+    resize = v2.Resize((resize_size, resize_size), antialias=True)
+    to_float = v2.ToDtype(torch.float32, scale=True)
+    normalize = v2.Normalize(
         mean=(0.485, 0.456, 0.406),
         std=(0.229, 0.224, 0.225),
     )
-    return transforms.Compose([to_tensor, resize, normalize])
+    return v2.Compose([to_tensor, resize, to_float, normalize])
 
 depther = torch.hub.load(REPO_DIR, 'dinov3_vit7b16_dd', source="local", weights=<DEPTHER/CHECKPOINT/URL/OR/PATH>, backbone_weights=<BACKBONE/CHECKPOINT/URL/OR/PATH>)
 
@@ -445,13 +450,14 @@ def get_img():
     return image
 
 def make_transform(resize_size: int | list[int] = 768):
-    to_tensor = transforms.ToTensor()
-    resize = transforms.Resize((resize_size, resize_size), antialias=True)
-    normalize = transforms.Normalize(
+    to_tensor = v2.ToImage()
+    resize = v2.Resize((resize_size, resize_size), antialias=True)
+    to_float = v2.ToDtype(torch.float32, scale=True)
+    normalize = v2.Normalize(
         mean=(0.485, 0.456, 0.406),
         std=(0.229, 0.224, 0.225),
     )
-    return transforms.Compose([to_tensor, resize, normalize])
+    return v2.Compose([to_tensor, resize, to_float, normalize])
 
 segmentor = torch.hub.load(REPO_DIR, 'dinov3_vit7b16_ms', source="local", weights=<SEGMENTOR/CHECKPOINT/URL/OR/PATH>, backbone_weights=<BACKBONE/CHECKPOINT/URL/OR/PATH>)
 

--- a/README.md
+++ b/README.md
@@ -245,13 +245,13 @@ from torchvision.transforms import v2
 
 def make_transform(resize_size: int = 224):
     to_tensor = v2.ToImage()
-    to_float = v2.ToDtype(torch.float32, scale=True)
     resize = v2.Resize((resize_size, resize_size), antialias=True)
+    to_float = v2.ToDtype(torch.float32, scale=True)
     normalize = v2.Normalize(
         mean=(0.485, 0.456, 0.406),
         std=(0.229, 0.224, 0.225),
     )
-    return v2.Compose([to_tensor, to_float, resize, normalize])
+    return v2.Compose([to_tensor, resize, to_float, normalize])
 ```
 
 
@@ -264,13 +264,13 @@ from torchvision.transforms import v2
 
 def make_transform(resize_size: int = 224):
     to_tensor = v2.ToImage()
-    to_float = v2.ToDtype(torch.float32, scale=True)
     resize = v2.Resize((resize_size, resize_size), antialias=True)
+    to_float = v2.ToDtype(torch.float32, scale=True)
     normalize = v2.Normalize(
         mean=(0.430, 0.411, 0.296),
         std=(0.213, 0.156, 0.143),
     )
-    return v2.Compose([to_tensor, to_float, resize, normalize])
+    return v2.Compose([to_tensor, resize, to_float, normalize])
 ```
 
 ### Pretrained heads - Image classification
@@ -348,13 +348,13 @@ def get_img():
 
 def make_transform(resize_size: int | list[int] = 768):
     to_tensor = v2.ToImage()
-    to_float = v2.ToDtype(torch.float32, scale=True)
     resize = v2.Resize((resize_size, resize_size), antialias=True)
+    to_float = v2.ToDtype(torch.float32, scale=True)
     normalize = v2.Normalize(
         mean=(0.485, 0.456, 0.406),
         std=(0.229, 0.224, 0.225),
     )
-    return v2.Compose([to_tensor, to_float, resize, normalize])
+    return v2.Compose([to_tensor, resize, to_float, normalize])
 
 depther = torch.hub.load(REPO_DIR, 'dinov3_vit7b16_dd', source="local", weights=<DEPTHER/CHECKPOINT/URL/OR/PATH>, backbone_weights=<BACKBONE/CHECKPOINT/URL/OR/PATH>)
 
@@ -451,13 +451,13 @@ def get_img():
 
 def make_transform(resize_size: int | list[int] = 768):
     to_tensor = v2.ToImage()
-    to_float = v2.ToDtype(torch.float32, scale=True)
     resize = v2.Resize((resize_size, resize_size), antialias=True)
+    to_float = v2.ToDtype(torch.float32, scale=True)
     normalize = v2.Normalize(
         mean=(0.485, 0.456, 0.406),
         std=(0.229, 0.224, 0.225),
     )
-    return v2.Compose([to_tensor, to_float, resize, normalize])
+    return v2.Compose([to_tensor, resize, to_float, normalize])
 
 segmentor = torch.hub.load(REPO_DIR, 'dinov3_vit7b16_ms', source="local", weights=<SEGMENTOR/CHECKPOINT/URL/OR/PATH>, backbone_weights=<BACKBONE/CHECKPOINT/URL/OR/PATH>)
 

--- a/dinov3/data/augmentations.py
+++ b/dinov3/data/augmentations.py
@@ -6,6 +6,7 @@
 import logging
 
 import numpy as np
+import torch
 from torch import nn
 from torchvision.transforms import v2
 

--- a/dinov3/data/augmentations.py
+++ b/dinov3/data/augmentations.py
@@ -7,7 +7,7 @@ import logging
 
 import numpy as np
 from torch import nn
-from torchvision import transforms
+from torchvision.transforms import v2
 
 from dinov3.data.transforms import IMAGENET_DEFAULT_MEAN, IMAGENET_DEFAULT_STD, GaussianBlur, make_normalize_transform
 
@@ -67,14 +67,14 @@ class DataAugmentationDINO(object):
         global_crop_max_size = max(global_crops_size, gram_teacher_crops_size if gram_teacher_crops_size else 0)
 
         # random resized crop and flip
-        self.geometric_augmentation_global = transforms.Compose(
+        self.geometric_augmentation_global = v2.Compose(
             [
-                transforms.RandomResizedCrop(
+                v2.RandomResizedCrop(
                     global_crop_max_size,
                     scale=global_crops_scale,
-                    interpolation=transforms.InterpolationMode.BICUBIC,
+                    interpolation=v2.InterpolationMode.BICUBIC,
                 ),
-                transforms.RandomHorizontalFlip(p=0.5 if horizontal_flips else 0.0),
+                v2.RandomHorizontalFlip(p=0.5 if horizontal_flips else 0.0),
             ]
         )
 
@@ -89,77 +89,78 @@ class DataAugmentationDINO(object):
                 # When there a no distortions for the gram teacher crop, we can resize before the distortions.
                 # This is the preferred order, because it keeps the image size for the augmentations consistent,
                 # which matters e.g. for GaussianBlur.
-                resize_global = transforms.Resize(
+                resize_global = v2.Resize(
                     global_crops_size,
-                    interpolation=transforms.InterpolationMode.BICUBIC,
+                    interpolation=v2.InterpolationMode.BICUBIC,
                 )
             else:
                 # When there a no distortions for the gram teacher crop, we need to resize after the distortions,
                 # because the distortions are shared between global and gram teacher crops.
-                self.resize_global_post_transf = transforms.Resize(
+                self.resize_global_post_transf = v2.Resize(
                     global_crops_size,
-                    interpolation=transforms.InterpolationMode.BICUBIC,
+                    interpolation=v2.InterpolationMode.BICUBIC,
                 )
 
-            self.resize_gram_teacher = transforms.Resize(
+            self.resize_gram_teacher = v2.Resize(
                 gram_teacher_crops_size,
-                interpolation=transforms.InterpolationMode.BICUBIC,
+                interpolation=v2.InterpolationMode.BICUBIC,
             )
 
-        self.geometric_augmentation_local = transforms.Compose(
+        self.geometric_augmentation_local = v2.Compose(
             [
-                transforms.RandomResizedCrop(
+                v2.RandomResizedCrop(
                     local_crops_size,
                     scale=local_crops_scale,
-                    interpolation=transforms.InterpolationMode.BICUBIC,
+                    interpolation=v2.InterpolationMode.BICUBIC,
                 ),
-                transforms.RandomHorizontalFlip(p=0.5 if horizontal_flips else 0.0),
+                v2.RandomHorizontalFlip(p=0.5 if horizontal_flips else 0.0),
             ]
         )
 
         # color distortions / blurring
-        color_jittering = transforms.Compose(
+        color_jittering = v2.Compose(
             [
-                transforms.RandomApply(
-                    [transforms.ColorJitter(brightness=0.4, contrast=0.4, saturation=0.2, hue=0.1)],
+                v2.RandomApply(
+                    [v2.ColorJitter(brightness=0.4, contrast=0.4, saturation=0.2, hue=0.1)],
                     p=0.8,
                 ),
-                transforms.RandomGrayscale(p=0.2),
+                v2.RandomGrayscale(p=0.2),
             ]
         )
 
         global_transfo1_extra = GaussianBlur(p=1.0)
 
-        global_transfo2_extra = transforms.Compose(
+        global_transfo2_extra = v2.Compose(
             [
                 GaussianBlur(p=0.1),
-                transforms.RandomSolarize(threshold=128, p=0.2),
+                v2.RandomSolarize(threshold=128, p=0.2),
             ]
         )
 
         local_transfo_extra = GaussianBlur(p=0.5)
 
         # normalization
-        self.normalize = transforms.Compose(
+        self.normalize = v2.Compose(
             [
-                transforms.ToTensor(),
+                v2.ToImage(),
+                v2.ToDtype(torch.float32, scale=True),
                 make_normalize_transform(mean=mean, std=std),
             ]
         )
 
         if self.share_color_jitter:
             self.color_jittering = color_jittering
-            self.global_transfo1 = transforms.Compose([resize_global, global_transfo1_extra, self.normalize])
-            self.global_transfo2 = transforms.Compose([resize_global, global_transfo2_extra, self.normalize])
-            self.local_transfo = transforms.Compose([local_transfo_extra, self.normalize])
+            self.global_transfo1 = v2.Compose([resize_global, global_transfo1_extra, self.normalize])
+            self.global_transfo2 = v2.Compose([resize_global, global_transfo2_extra, self.normalize])
+            self.local_transfo = v2.Compose([local_transfo_extra, self.normalize])
         else:
-            self.global_transfo1 = transforms.Compose(
+            self.global_transfo1 = v2.Compose(
                 [resize_global, color_jittering, global_transfo1_extra, self.normalize]
             )
-            self.global_transfo2 = transforms.Compose(
+            self.global_transfo2 = v2.Compose(
                 [resize_global, color_jittering, global_transfo2_extra, self.normalize]
             )
-            self.local_transfo = transforms.Compose([color_jittering, local_transfo_extra, self.normalize])
+            self.local_transfo = v2.Compose([color_jittering, local_transfo_extra, self.normalize])
 
     def __call__(self, image):
         output = {}

--- a/dinov3/data/transforms.py
+++ b/dinov3/data/transforms.py
@@ -49,7 +49,6 @@ def make_base_transform(
 ) -> v2.Normalize:
     return v2.Compose(
         [
-            v2.ToImage(),
             v2.ToDtype(torch.float32, scale=True),
             make_normalize_transform(mean=mean, std=std),
         ]
@@ -66,7 +65,7 @@ def make_classification_train_transform(
     mean: Sequence[float] = IMAGENET_DEFAULT_MEAN,
     std: Sequence[float] = IMAGENET_DEFAULT_STD,
 ):
-    transforms_list = [v2.RandomResizedCrop(crop_size, interpolation=interpolation)]
+    transforms_list = [v2.ToImage(), v2.RandomResizedCrop(crop_size, interpolation=interpolation)]
     if hflip_prob > 0.0:
         transforms_list.append(v2.RandomHorizontalFlip(hflip_prob))
     transforms_list.append(make_base_transform(mean, std))
@@ -108,7 +107,7 @@ def make_eval_transform(
     mean: Sequence[float] = IMAGENET_DEFAULT_MEAN,
     std: Sequence[float] = IMAGENET_DEFAULT_STD,
 ) -> v2.Compose:
-    transforms_list = []
+    transforms_list = [v2.ToImage()]
     resize_transform = make_resize_transform(
         resize_size=resize_size,
         resize_square=resize_square,

--- a/dinov3/data/transforms.py
+++ b/dinov3/data/transforms.py
@@ -4,21 +4,19 @@
 # the terms of the DINOv3 License Agreement.
 
 import logging
-import math
 from typing import Sequence
 
-import PIL
 import torch
-from torchvision import transforms
+from torchvision.transforms import v2
 
 logger = logging.getLogger("dinov3")
 
 
-def make_interpolation_mode(mode_str: str) -> transforms.InterpolationMode:
-    return {mode.value: mode for mode in transforms.InterpolationMode}[mode_str]
+def make_interpolation_mode(mode_str: str) -> v2.InterpolationMode:
+    return {mode.value: mode for mode in v2.InterpolationMode}[mode_str]
 
 
-class GaussianBlur(transforms.RandomApply):
+class GaussianBlur(v2.RandomApply):
     """
     Apply Gaussian Blur to the PIL image.
     """
@@ -26,25 +24,8 @@ class GaussianBlur(transforms.RandomApply):
     def __init__(self, *, p: float = 0.5, radius_min: float = 0.1, radius_max: float = 2.0):
         # NOTE: torchvision is applying 1 - probability to return the original image
         keep_p = 1 - p
-        transform = transforms.GaussianBlur(kernel_size=9, sigma=(radius_min, radius_max))
-        super().__init__(transforms=[transform], p=keep_p)
-
-
-class MaybeToTensor(transforms.ToTensor):
-    """
-    Convert a ``PIL Image`` or ``numpy.ndarray`` to tensor, or keep as is if already a tensor.
-    """
-
-    def __call__(self, pic):
-        """
-        Args:
-            pic (PIL Image, numpy.ndarray or torch.tensor): Image to be converted to tensor.
-        Returns:
-            Tensor: Converted image.
-        """
-        if isinstance(pic, torch.Tensor):
-            return pic
-        return super().__call__(pic)
+        transform = v2.GaussianBlur(kernel_size=9, sigma=(radius_min, radius_max))
+        super().__init__(v2=[transform], p=keep_p)
 
 
 # Use timm's names
@@ -58,17 +39,18 @@ RESIZE_DEFAULT_SIZE = int(256 * CROP_DEFAULT_SIZE / 224)
 def make_normalize_transform(
     mean: Sequence[float] = IMAGENET_DEFAULT_MEAN,
     std: Sequence[float] = IMAGENET_DEFAULT_STD,
-) -> transforms.Normalize:
-    return transforms.Normalize(mean=mean, std=std)
+) -> v2.Normalize:
+    return v2.Normalize(mean=mean, std=std)
 
 
 def make_base_transform(
     mean: Sequence[float] = IMAGENET_DEFAULT_MEAN,
     std: Sequence[float] = IMAGENET_DEFAULT_STD,
-) -> transforms.Normalize:
-    return transforms.Compose(
+) -> v2.Normalize:
+    return v2.Compose(
         [
-            MaybeToTensor(),
+            v2.ToImage(),
+            v2.ToDtype(torch.float32, scale=True),
             make_normalize_transform(mean=mean, std=std),
         ]
     )
@@ -79,43 +61,18 @@ def make_base_transform(
 def make_classification_train_transform(
     *,
     crop_size: int = CROP_DEFAULT_SIZE,
-    interpolation=transforms.InterpolationMode.BICUBIC,
+    interpolation=v2.InterpolationMode.BICUBIC,
     hflip_prob: float = 0.5,
     mean: Sequence[float] = IMAGENET_DEFAULT_MEAN,
     std: Sequence[float] = IMAGENET_DEFAULT_STD,
 ):
-    transforms_list = [transforms.RandomResizedCrop(crop_size, interpolation=interpolation)]
+    v2_list = [v2.RandomResizedCrop(crop_size, interpolation=interpolation)]
     if hflip_prob > 0.0:
-        transforms_list.append(transforms.RandomHorizontalFlip(hflip_prob))
-    transforms_list.append(make_base_transform(mean, std))
-    transform = transforms.Compose(transforms_list)
+        v2_list.append(v2.RandomHorizontalFlip(hflip_prob))
+    v2_list.append(make_base_transform(mean, std))
+    transform = v2.Compose(transforms_list)
     logger.info(f"Built classification train transform\n{transform}")
     return transform
-
-
-class _MaxSizeResize(object):
-    def __init__(
-        self,
-        max_size: int,
-        interpolation: transforms.InterpolationMode,
-    ):
-        self._size = self._make_size(max_size)
-        self._resampling = self._make_resampling(interpolation)
-
-    def _make_size(self, max_size: int):
-        return (max_size, max_size)
-
-    def _make_resampling(self, interpolation: transforms.InterpolationMode):
-        if interpolation == transforms.InterpolationMode.BICUBIC:
-            return PIL.Image.Resampling.BICUBIC
-        if interpolation == transforms.InterpolationMode.BILINEAR:
-            return PIL.Image.Resampling.BILINEAR
-        assert interpolation == transforms.InterpolationMode.NEAREST
-        return PIL.Image.Resampling.NEAREST
-
-    def __call__(self, image):
-        image.thumbnail(size=self._size, resample=self._resampling)
-        return image
 
 
 def make_resize_transform(
@@ -123,20 +80,20 @@ def make_resize_transform(
     resize_size: int,
     resize_square: bool = False,
     resize_large_side: bool = False,  # Set the larger side to resize_size instead of the smaller
-    interpolation: transforms.InterpolationMode = transforms.InterpolationMode.BICUBIC,
+    interpolation: v2.InterpolationMode = v2.InterpolationMode.BICUBIC,
 ):
     assert not (resize_square and resize_large_side), "These two options can not be set together"
     if resize_square:
         logger.info("resizing image as a square")
         size = (resize_size, resize_size)
-        transform = transforms.Resize(size=size, interpolation=interpolation)
+        transform = v2.Resize(size=size, interpolation=interpolation)
         return transform
     elif resize_large_side:
         logger.info("resizing based on large side")
-        transform = _MaxSizeResize(max_size=resize_size, interpolation=interpolation)
+        transform = v2.Resize(max_size=size, interpolation=interpolation)
         return transform
     else:
-        transform = transforms.Resize(resize_size, interpolation=interpolation)
+        transform = v2.Resize(resize_size, interpolation=interpolation)
         return transform
 
 
@@ -147,10 +104,10 @@ def make_eval_transform(
     crop_size: int = CROP_DEFAULT_SIZE,
     resize_square: bool = False,
     resize_large_side: bool = False,  # Set the larger side to resize_size instead of the smaller
-    interpolation: transforms.InterpolationMode = transforms.InterpolationMode.BICUBIC,
+    interpolation: v2.InterpolationMode = v2.InterpolationMode.BICUBIC,
     mean: Sequence[float] = IMAGENET_DEFAULT_MEAN,
     std: Sequence[float] = IMAGENET_DEFAULT_STD,
-) -> transforms.Compose:
+) -> v2.Compose:
     transforms_list = []
     resize_transform = make_resize_transform(
         resize_size=resize_size,
@@ -160,9 +117,9 @@ def make_eval_transform(
     )
     transforms_list.append(resize_transform)
     if crop_size:
-        transforms_list.append(transforms.CenterCrop(crop_size))
+        transforms_list.append(v2.CenterCrop(crop_size))
     transforms_list.append(make_base_transform(mean, std))
-    transform = transforms.Compose(transforms_list)
+    transform = v2.Compose(transforms_list)
     logger.info(f"Built eval transform\n{transform}")
     return transform
 
@@ -173,10 +130,10 @@ def make_classification_eval_transform(
     *,
     resize_size: int = RESIZE_DEFAULT_SIZE,
     crop_size: int = CROP_DEFAULT_SIZE,
-    interpolation=transforms.InterpolationMode.BICUBIC,
+    interpolation=v2.InterpolationMode.BICUBIC,
     mean: Sequence[float] = IMAGENET_DEFAULT_MEAN,
     std: Sequence[float] = IMAGENET_DEFAULT_STD,
-) -> transforms.Compose:
+) -> v2.Compose:
     return make_eval_transform(
         resize_size=resize_size,
         crop_size=crop_size,
@@ -186,27 +143,6 @@ def make_classification_eval_transform(
         resize_square=False,
         resize_large_side=False,
     )
-
-
-class MultipleResize(object):
-    # A resize transform that makes the large side a multiple of a given number. That might change the aspect ratio.
-    def __init__(self, interpolation=transforms.InterpolationMode.BILINEAR, multiple=1):
-        self.multiple = multiple
-        self.interpolation = interpolation
-
-    def __call__(self, img):
-        if self.multiple == 1:
-            return img
-        if hasattr(img, "shape"):
-            h, w = img.shape[-2:]
-        else:
-            assert isinstance(
-                img, PIL.Image.Image
-            ), f"img should have a `shape` attribute or be a PIL Image, got {type(img)}"
-            w, h = img.size
-        new_h, new_w = [math.ceil(s / self.multiple) * self.multiple for s in (h, w)]
-        resized_image = transforms.functional.resize(img, (new_h, new_w))
-        return resized_image
 
 
 def voc2007_classification_target_transform(label, n_categories=20):

--- a/dinov3/data/transforms.py
+++ b/dinov3/data/transforms.py
@@ -66,10 +66,10 @@ def make_classification_train_transform(
     mean: Sequence[float] = IMAGENET_DEFAULT_MEAN,
     std: Sequence[float] = IMAGENET_DEFAULT_STD,
 ):
-    v2_list = [v2.RandomResizedCrop(crop_size, interpolation=interpolation)]
+    transforms_list = [v2.RandomResizedCrop(crop_size, interpolation=interpolation)]
     if hflip_prob > 0.0:
-        v2_list.append(v2.RandomHorizontalFlip(hflip_prob))
-    v2_list.append(make_base_transform(mean, std))
+        transforms_list.append(v2.RandomHorizontalFlip(hflip_prob))
+    transforms_list.append(make_base_transform(mean, std))
     transform = v2.Compose(transforms_list)
     logger.info(f"Built classification train transform\n{transform}")
     return transform

--- a/dinov3/data/transforms.py
+++ b/dinov3/data/transforms.py
@@ -90,7 +90,7 @@ def make_resize_transform(
         return transform
     elif resize_large_side:
         logger.info("resizing based on large side")
-        transform = v2.Resize(max_size=size, interpolation=interpolation)
+        transform = v2.Resize(size=None, max_size=resize_size, interpolation=interpolation)
         return transform
     else:
         transform = v2.Resize(resize_size, interpolation=interpolation)

--- a/dinov3/data/transforms.py
+++ b/dinov3/data/transforms.py
@@ -25,7 +25,7 @@ class GaussianBlur(v2.RandomApply):
         # NOTE: torchvision is applying 1 - probability to return the original image
         keep_p = 1 - p
         transform = v2.GaussianBlur(kernel_size=9, sigma=(radius_min, radius_max))
-        super().__init__(v2=[transform], p=keep_p)
+        super().__init__(transforms=[transform], p=keep_p)
 
 
 # Use timm's names


### PR DESCRIPTION
This PR is a proposition to update torchvision transforms to v2, which offers more features and increased performance. 

## Proposed Modifications

The PR modifies the transform sequence such that all transforms follows the following sequence: `to_tensor, resize, to_float, normalize`. Thus transformations are operated on `torch.Tensor` instead of PIL images. There should be feature parity between the two transformations (c.f. comparison [here](https://gist.github.com/NicolasHug/2cc5e229827852bac9ae7218f6f1f344)). However, the transforms on tensors should be more efficient.

## Detailed Modifications

This PR proposes to implement the following modifications:
* Update README.md file with the v2 of torchvision transforms;
* Update data/augmentation.py file with the v2 of torchvision transforms;
* Modify data/transforms.py file by replacing the class `MaybeToTensor()` with `v2.ToImage()` and `v2.ToDtype(torch.float32, scale=True)` as recommended in the [documentation](https://docs.pytorch.org/vision/main/generated/torchvision.transforms.v2.ToTensor.html?highlight=totensor#torchvision.transforms.v2.ToTensor). Replacing the `_MaxSizeResize` using PIL with `v2.Resize(size=None, max_size=size, interpolation=interpolation)`. Removing the unused `MultipleResize` class. This allows to remove any PIL and math import.

## Testing

The following code snippet output the same features than the one proposed in the README. I would also be happy to add unit tests to control feature parity if needed.

```python
import torch
from torchvision import transforms
from torchvision.transforms import v2

def get_img():
    import requests

    url = "http://images.cocodataset.org/val2017/000000039769.jpg"
    image = Image.open(requests.get(url, stream=True).raw).convert("RGB")
    return image

def make_transform(resize_size: int = 768):
    to_tensor = v2.ToImage()
    to_float = v2.ToDtype(torch.float32, scale=True)
    resize = v2.Resize((resize_size, resize_size), antialias=True)
    normalize = v2.Normalize(
        mean=(0.485, 0.456, 0.406),
        std=(0.229, 0.224, 0.225),
    )
    return v2.Compose([to_tensor, to_float, resize, normalize])

img_size = 896
img = get_img()
transform = make_transform(img_size)
batch_img = transform(img)[None]

img_size = 896
img = get_img()
transform = make_transform(img_size)
with torch.inference_mode():
    with torch.autocast("cuda", dtype=torch.bfloat16):
        batch_img = transform(img)[None]
        pred_vit7b = dinov3_vits16(batch_img)  # raw predictions
```