### PR TITLE
Fix Gram anchoring bug

### DIFF
--- a/dinov3/train/ssl_meta_arch.py
+++ b/dinov3/train/ssl_meta_arch.py
@@ -482,7 +482,7 @@ class SSLMetaArch(nn.Module):
 
             with torch.no_grad():
                 backbone_out = self.gram_teacher.backbone(images, is_training=True)
-            teacher_patches = backbone_out.x_norm_patchtokens  # [n_crops * B, P_T, D]
+            teacher_patches = backbone_out["x_norm_patchtokens"]  # [n_crops * B, P_T, D]
 
             # Downsample Gram teacher features if needed
             if teacher_patches.shape[1] != student_patches.shape[1]:


### PR DESCRIPTION
A bug was introduced when we changed the vision transformer forward output from named_tuple to dictionary. This PR fixes that. Fixes #139 , thanks @yzy0102 for reporting this and sending a PR
