### PR TITLE
Bug fix: drop_path_rate should be 0.0

### DIFF
--- a/dinov3/hub/backbones.py
+++ b/dinov3/hub/backbones.py
@@ -477,7 +477,7 @@ def dinov3_vit7b16(
         num_heads=32,
         ffn_ratio=3,
         qkv_bias=False,
-        drop_path_rate=0.4,
+        drop_path_rate=0.0,
         layerscale_init=1.0e-05,
         norm_layer="layernormbf16",
         ffn_layer="swiglu64",


### PR DESCRIPTION
**Summary**

Drop path rate should be 0.0 for DINOv3 backbones