### PR TITLE
Bug fix in sharding bias_mask

### DIFF
--- a/dinov3/train/ssl_meta_arch.py
+++ b/dinov3/train/ssl_meta_arch.py
@@ -307,13 +307,13 @@ class SSLMetaArch(nn.Module):
                 init_fsdp_model_from_checkpoint(
                     self.gram_teacher,
                     self.gram_ckpt,
-                    skip_load_prefixes=[
+                    skip_load_keys=[
                         "dino_head",
                         "ibot_head",
                         "dino_loss.center",
                         "ibot_patch_loss.center",
                     ],
-                    prefixes_not_sharded=["backbone.rope_embed.periods"],
+                    keys_not_sharded=["backbone.rope_embed.periods", "qkv.bias_mask"],
                     process_group=distributed.get_default_process_group(),
                 )
                 self.gram_teacher_initialized = True
@@ -326,8 +326,8 @@ class SSLMetaArch(nn.Module):
             init_fsdp_model_from_checkpoint(
                 self.student,
                 self.cfg.student.resume_from_teacher_chkpt,
-                skip_load_prefixes=["dino_loss.center", "ibot_patch_loss.center"],
-                prefixes_not_sharded=["backbone.rope_embed.periods"],
+                skip_load_keys=["dino_loss.center", "ibot_patch_loss.center"],
+                keys_not_sharded=["backbone.rope_embed.periods", "qkv.bias_mask"],
                 process_group=distributed.get_process_subgroup(),
             )
             self.model_ema.load_state_dict(self.student.state_dict())
@@ -337,7 +337,8 @@ class SSLMetaArch(nn.Module):
                 init_fsdp_model_from_checkpoint(
                     self.teacher,
                     self.cfg.distillation.checkpoint_path,
-                    skip_load_prefixes=[],
+                    skip_load_keys=["dino_loss.center", "ibot_patch_loss.center"],
+                    keys_not_sharded=["backbone.rope_embed.periods", "qkv.bias_mask"],
                 )
             else:
                 logger.info("Init teacher to distil from, used for testing purpose only")


### PR DESCRIPTION
**Summary**

When loading PyTorch standard checkpoints (not DCP) for HRFT or Gram, the loader tries to shard bias_mask parameter which should not be sharded and this PR fixes that. I also took the liberty to rename few variables to improve clarity.

**Test plan**

Tested with a small HRFT and Gram anchoring work load everything is working as expected plus handling consolidated checkpoints with bias_mask parameter
 
