### PR TITLE
removing dead cond

### DIFF
--- a/dinov3/loss/gram_loss.py
+++ b/dinov3/loss/gram_loss.py
@@ -79,6 +79,5 @@ class GramLoss(nn.Module):
         elif self.remove_only_teacher_neg:
             # Remove only the negative sim values of the teacher
             target_sim[target_sim < 0] = 0.0
-            student_sim[(student_sim < 0) & (target_sim < 0)] = 0.0
-
+            
         return self.mse_loss(student_sim, target_sim)


### PR DESCRIPTION
in the gram loss class, when the `remove_only_teacher_neg` the current implementation set all negative values in teacher feature map to 0 (as intended) then use a dead condition (negative values existence in teacher's feature map immediately after setting them to zero) to update the student feature map, which is an unnecessary op