### PR TITLE
Fix aspect ratio formula

### DIFF
--- a/dinov3/data/masking.py
+++ b/dinov3/data/masking.py
@@ -52,8 +52,8 @@ class MaskingGenerator:
         for _ in range(10):
             target_area = random.uniform(self.min_num_patches, max_mask_patches)
             aspect_ratio = math.exp(random.uniform(*self.log_aspect_ratio))
-            h = int(round(math.sqrt(target_area * aspect_ratio)))
-            w = int(round(math.sqrt(target_area / aspect_ratio)))
+            h = int(round(math.sqrt(target_area / aspect_ratio)))
+            w = int(round(math.sqrt(target_area * aspect_ratio)))
             if w < self.width and h < self.height:
                 top = random.randint(0, self.height - h)
                 left = random.randint(0, self.width - w)


### PR DESCRIPTION
The current implementation in MaskingGenerator calculates:

    h = sqrt(target_area * aspect_ratio)
    w = sqrt(target_area / aspect_ratio)

However, this does not align with the common definition of aspect ratio (w/h).  
This PR revises the formula as follows:

    h = sqrt(target_area / aspect_ratio)
    w = sqrt(target_area * aspect_ratio)

This change ensures consistency with the conventional aspect ratio definition and follows the implementation in torchvision’s RandomResizedCrop.