### PR TITLE
Fix remove teacher only negative values

### DIFF
--- a/dinov3/loss/gram_loss.py
+++ b/dinov3/loss/gram_loss.py
@@ -78,7 +78,8 @@ class GramLoss(nn.Module):
 
         elif self.remove_only_teacher_neg:
             # Remove only the negative sim values of the teacher
-            target_sim[target_sim < 0] = 0.0
-            student_sim[(student_sim < 0) & (target_sim < 0)] = 0.0
+            target_sim_b_table = target_sim < 0
+            target_sim[target_sim_b_table] = 0.0
+            student_sim[(student_sim < 0) & target_sim_b_table] = 0.0
 
         return self.mse_loss(student_sim, target_sim)


### PR DESCRIPTION
I'm not sure if this is relevant for the maintainers. but the implementation for removing negative values of teacher for gram loss seems buggy to me.

Ideally one would remove the entries of student that are negative in the teacher.

However, feel free to ignore if this is irrelevant.