### PR TITLE
Fix logging formatter crash when record.msg is not a string

### DIFF
--- a/dinov3/logging/__init__.py
+++ b/dinov3/logging/__init__.py
@@ -35,7 +35,9 @@ class _LevelColoredFormatter(logging.Formatter):
         if colored_kwargs is None:
             return log
 
-        msg = record.msg % record.args if record.msg == "%s" else record.msg
+        raw_msg = record.getMessage()
+        msg = str(raw_msg)
+        
         index = log.rfind(msg, len(log) - len(msg))
         # Can happen in some cases, like if the msg contains `%s` which
         # have been replaced in `formatMessage`. Fallback to no colors


### PR DESCRIPTION
Hi,

I am opening this PR because the custom `_LevelColoredFormatter` class assumed `record.msg` was always a string, which caused a TypeError when logging non-string objects (e.g., `DictConfig`). This patch replaces direct `record.msg` access with `record.getMessage()`, ensuring consistent string formatting and preventing crashes.

Best,

Daniel