### PR TITLE
[bugfix] Fix distillation from unsharded teacher checkpoint

### DIFF
--- a/dinov3/train/ssl_meta_arch.py
+++ b/dinov3/train/ssl_meta_arch.py
@@ -339,6 +339,7 @@ class SSLMetaArch(nn.Module):
                     self.cfg.distillation.checkpoint_path,
                     skip_load_keys=["dino_loss.center", "ibot_patch_loss.center"],
                     keys_not_sharded=["backbone.rope_embed.periods", "qkv.bias_mask"],
+                    process_group=distributed.get_default_process_group(),
                 )
             else:
                 logger.info("Init teacher to distil from, used for testing purpose only")


### PR DESCRIPTION
**Summary**

We were not passing process group when loading teacher checkpoints for distillation and this caused a bug when distilling from unsharded checkpoints. This PR fixes that.

**Test plan**

Tested with the multi-distillation example run from README and verified that we can load unsharded as well as sharded checkpoints for distillation