### PR TITLE
[bug fix]  Average the gradients instead of sum

### DIFF
--- a/dinov3/fsdp/ac_compile_parallelize.py
+++ b/dinov3/fsdp/ac_compile_parallelize.py
@@ -145,7 +145,7 @@ def ac_compile_parallelize(
             for prev_block, next_block in zip(blocks, blocks[1:]):
                 prev_block.set_modules_to_forward_prefetch([next_block])
                 next_block.set_modules_to_backward_prefetch([prev_block])
-            fully_shard(m.backbone, **fsdp_config, reshard_after_forward=True).set_reduce_scatter_divide_factor(1)
+            fully_shard(m.backbone, **fsdp_config, reshard_after_forward=True)
             register_fsdp_forward_method(m.backbone, "get_intermediate_layers")
 
     # 4/ Move to `cuda` device


### PR DESCRIPTION
**Summary**

For all the pre-training runs we did with FSDP2 we observed that averaging the gradients during FSDP2 all gather resulted stable runs and summing the gradients led to NANs in large scale setup. This was overlooked in  the DINOv3 codebase and this PR fixes that.

**Test plan**

We have tested thoroughly this setup for all the pre-training runs we did for DINOv3.

