### PR TITLE
Fix: gram loss does not zero `student_sim` when `remove_only_teacher_neg` is true

### DIFF
--- a/dinov3/loss/gram_loss.py
+++ b/dinov3/loss/gram_loss.py
@@ -78,7 +78,7 @@ class GramLoss(nn.Module):
 
         elif self.remove_only_teacher_neg:
             # Remove only the negative sim values of the teacher
-            target_sim[target_sim < 0] = 0.0
             student_sim[(student_sim < 0) & (target_sim < 0)] = 0.0
+            target_sim[target_sim < 0] = 0.0
 
         return self.mse_loss(student_sim, target_sim)


### PR DESCRIPTION
student_sim values corresponding to negative target_sim entries are never zeroed, since the teacher mask is applied before the student masking step (making the condition `target_sim < 0` always false)