### PR TITLE
[eval][segmentation] Make more parameters configurable

### DIFF
--- a/dinov3/eval/segmentation/config.py
+++ b/dinov3/eval/segmentation/config.py
@@ -63,6 +63,7 @@ class DecoderConfig:
     use_backbone_norm: bool = True  # Uses the backbone's output normalization on all layers
     num_classes: int = 150  # Number of segmentation classes
     hidden_dim: int = 2048  # Hidden dimension, only used for M2F head
+    dropout: float = 0.1  # Dropout ratio in the linear head during training
 
 
 @dataclass

--- a/dinov3/eval/segmentation/eval.py
+++ b/dinov3/eval/segmentation/eval.py
@@ -94,6 +94,7 @@ def test_segmentation(backbone, config):
             hidden_dim=config.decoder_head.hidden_dim,  # Only used for instantiating a M2F head
             num_classes=config.decoder_head.num_classes,
             autocast_dtype=config.model_dtype.autocast_dtype,
+            dropout=config.decoder_head.dropout,
         )
         state_dict = torch.load(config.load_from, map_location="cpu")["model"]
         _, _ = segmentation_model.load_state_dict(state_dict, strict=False)
@@ -108,6 +109,8 @@ def test_segmentation(backbone, config):
         inference_mode="slide",
         use_tta=config.eval.use_tta,
         tta_ratios=config.transforms.eval.tta_ratios,
+        mean=config.transforms.mean,
+        std=config.transforms.std,
     )
 
     test_dataset = DatasetWithEnumeratedTargets(

--- a/dinov3/eval/segmentation/models/__init__.py
+++ b/dinov3/eval/segmentation/models/__init__.py
@@ -79,6 +79,7 @@ def build_segmentation_decoder(
     decoder_type="linear",
     hidden_dim=2048,
     num_classes=150,
+    dropout=0.1,
     autocast_dtype=torch.float32,
 ):
     backbone_indices_to_use = _get_backbone_out_indices(backbone_model, backbone_out_layers)
@@ -121,6 +122,7 @@ def build_segmentation_decoder(
         decoder = LinearHead(
             in_channels=embed_dim,
             n_output_channels=num_classes,
+            dropout=dropout,
         )
     else:
         raise ValueError(f'Unsupported decoder "{decoder_type}"')

--- a/dinov3/eval/segmentation/models/heads/linear_head.py
+++ b/dinov3/eval/segmentation/models/heads/linear_head.py
@@ -17,6 +17,7 @@ class LinearHead(nn.Module):
         n_output_channels,
         use_batchnorm=True,
         use_cls_token=False,
+        dropout=0.1,
     ):
         super().__init__()
         self.in_channels = in_channels
@@ -27,7 +28,7 @@ class LinearHead(nn.Module):
         self.use_cls_token = use_cls_token
         self.batchnorm_layer = nn.SyncBatchNorm(self.channels) if use_batchnorm else nn.Identity(self.channels)
         self.conv = nn.Conv2d(self.channels, self.n_output_channels, kernel_size=1, padding=0, stride=1)
-        self.dropout = nn.Dropout2d(0.1)
+        self.dropout = nn.Dropout2d(dropout)
         nn.init.normal_(self.conv.weight, mean=0, std=0.01)
         nn.init.constant_(self.conv.bias, 0)
 

--- a/dinov3/eval/segmentation/train.py
+++ b/dinov3/eval/segmentation/train.py
@@ -156,6 +156,7 @@ def train_segmentation(
         "linear",
         num_classes=config.decoder_head.num_classes,
         autocast_dtype=config.model_dtype.autocast_dtype,
+        dropout=config.decoder_head.dropout,
     )
     global_device = distributed.get_rank()
     local_device = torch.cuda.current_device()
@@ -172,10 +173,14 @@ def train_segmentation(
         crop_size=config.transforms.train.crop_size,
         flip_prob=config.transforms.train.flip_prob,
         reduce_zero_label=config.eval.reduce_zero_label,
+        mean=config.transforms.mean,
+        std=config.transforms.std,
     )
     val_transforms = make_segmentation_eval_transforms(
         img_size=config.transforms.eval.img_size,
         inference_mode=config.eval.mode,
+        mean=config.transforms.mean,
+        std=config.transforms.std,
     )
 
     train_dataset = DatasetWithEnumeratedTargets(


### PR DESCRIPTION
Making `transforms.mean`, `transforms.std`, and linear head `dropout` configurable