### PR TITLE
Misspelling correction

### DIFF
--- a/notebooks/pca.ipynb
+++ b/notebooks/pca.ipynb
@@ -176,7 +176,7 @@
     "IMAGENET_MEAN = (0.485, 0.456, 0.406)\n",
     "IMAGENET_STD = (0.229, 0.224, 0.225)\n",
     "\n",
-    "image_uri = \"https://dl.fbaipublicfiles.com/dinov3/notebooks/pca/test_image.jpg\"\n",
+    "image_url = \"https://dl.fbaipublicfiles.com/dinov3/notebooks/pca/test_image.jpg\"\n",
     "\n",
     "def load_image_from_url(url: str) -> Image:\n",
     "    with urllib.request.urlopen(url) as f:\n",
@@ -194,7 +194,7 @@
     "    return TF.to_tensor(TF.resize(mask_image, (h_patches * patch_size, w_patches * patch_size)))\n",
     "\n",
     "\n",
-    "image = load_image_from_url(image_uri)\n",
+    "image = load_image_from_url(image_url)\n",
     "image_resized = resize_transform(image)\n",
     "image_resized_norm = TF.normalize(image_resized, mean=IMAGENET_MEAN, std=IMAGENET_STD)"
    ]


### PR DESCRIPTION
Misspelling Correction: ‘uri' -> 'url'
Thanks.