### PR TITLE
<BUG> Fix ffn_ratio from 4 to 6.0 for ViT h16 plus

### DIFF
--- a/dinov3/models/vision_transformer.py
+++ b/dinov3/models/vision_transformer.py
@@ -383,7 +383,7 @@ def vit_huge2(patch_size=16, **kwargs):
         embed_dim=1280,
         depth=32,
         num_heads=20,
-        ffn_ratio=4,
+        ffn_ratio=6.0,
         **kwargs,
     )
     return model


### PR DESCRIPTION
The default `ffn_ratio` in the [dinov3/models/vision_transformer](https://github.com/facebookresearch/dinov3/blob/main/dinov3/models/vision_transformer.py) does not match the value defined in the provided vit-h16plus checkpoint as well as the one in [dinov3/hub/backbone](https://github.com/facebookresearch/dinov3/blob/main/dinov3/hub/backbones.py#L434), leading to a failure when loading the pretrained h16plus checkpoint using architecture defined in dinov3/models/vision_transformer.

