### PR TITLE
Add FSDP2 reshard_after_forward training config

### DIFF
--- a/dinov3/configs/config.py
+++ b/dinov3/configs/config.py
@@ -21,6 +21,26 @@ from dinov3.utils import fix_random_seeds, get_conda_env, get_sha
 logger = logging.getLogger("dinov3")
 
 
+def _warn_deprecated_sharding_strategy(*cfgs: DictConfig) -> None:
+    found_deprecated_key = False
+    for cfg in cfgs:
+        # We check for 'compute_precision' block presence
+        if not OmegaConf.is_config(cfg) or "compute_precision" not in cfg:
+            continue
+        # Then check for 'compute_precision.sharding_strategy'
+        compute_precision_cfg = cfg.compute_precision
+        if not OmegaConf.is_config(compute_precision_cfg) or "sharding_strategy" not in compute_precision_cfg:
+            continue
+        # Delete it
+        del compute_precision_cfg["sharding_strategy"]
+        found_deprecated_key = True
+    if found_deprecated_key:
+        logger.warning(
+            "`compute_precision.sharding_strategy` is deprecated and ignored. "
+            "Use `train.fsdp_reshard_after_forward` instead."
+        )
+
+
 @dataclass
 class DinoV3SetupArgs:
     config_file: str
@@ -78,6 +98,7 @@ def get_cfg_from_args(args: DinoV3SetupArgs, multidistillation=False, strict=Tru
 
     # Command line overrides
     opts_cfg = OmegaConf.from_cli(overrides)
+    _warn_deprecated_sharding_strategy(cfg, opts_cfg)
 
     if multidistillation:
         cfg = OmegaConf.merge(cfg, opts_cfg)
@@ -123,6 +144,8 @@ def setup_multidistillation(args: DinoV3SetupArgs):
     os.makedirs(args.output_dir, exist_ok=True)
     # get config file for this rank
     base_cfg = OmegaConf.load(args.config_file)
+    _warn_deprecated_sharding_strategy(base_cfg)
+
     assert base_cfg.multidistillation.enabled
 
     global_batch_size = base_cfg.multidistillation.global_batch_size
@@ -157,7 +180,10 @@ def setup_multidistillation(args: DinoV3SetupArgs):
     args.config_file = os.path.abspath(config_path)
     default_cfg = get_default_config()
     cfg = OmegaConf.load(args.config_file)
-    cfg = OmegaConf.merge(default_cfg, cfg, base_cfg, OmegaConf.from_cli(args.opts))
+    opts_cfg = OmegaConf.from_cli(args.opts)
+    _warn_deprecated_sharding_strategy(cfg, base_cfg, opts_cfg)
+
+    cfg = OmegaConf.merge(default_cfg, cfg, base_cfg, opts_cfg)
 
     global logger
     setup_logging(output=args.output_dir, level=logging.INFO)

--- a/dinov3/configs/ssl_default_config.yaml
+++ b/dinov3/configs/ssl_default_config.yaml
@@ -6,7 +6,6 @@ MODEL:
 compute_precision:
   param_dtype: bf16
   reduce_dtype: fp32
-  sharding_strategy: SHARD_GRAD_OP
 dino:
   loss_weight: 1.0
   global_ignore_diagonal: true  # Whether to ignore A-A and B-B global pairs, default as in DINOv2, ignored by SSLMetaArch
@@ -79,6 +78,7 @@ train:
   checkpointing_full: false  # aggressive checkpointing
   compile: true
   cudagraphs: false
+  fsdp_reshard_after_forward: true
   sharded_eval_checkpoint: false
   cache_dataset: false
 student:

--- a/dinov3/configs/train/dinov3_vit7b16_gram_anchor.yaml
+++ b/dinov3/configs/train/dinov3_vit7b16_gram_anchor.yaml
@@ -6,7 +6,6 @@ MODEL:
 compute_precision:
   param_dtype: bf16
   reduce_dtype: fp32
-  sharding_strategy: SHARD_GRAD_OP
 dino:
   loss_weight: 1.0
   global_ignore_diagonal: true
@@ -84,6 +83,7 @@ train:
   checkpointing_full: true
   compile: true
   cudagraphs: false
+  fsdp_reshard_after_forward: true
   cell_augmentation: false
   cell_augmentation_type: hpa
   sharded_eval_checkpoint: true

--- a/dinov3/configs/train/dinov3_vit7b16_high_res_adapt.yaml
+++ b/dinov3/configs/train/dinov3_vit7b16_high_res_adapt.yaml
@@ -6,7 +6,6 @@ MODEL:
 compute_precision:
   param_dtype: bf16
   reduce_dtype: fp32
-  sharding_strategy: SHARD_GRAD_OP
 dino:
   loss_weight: 1.0
   global_ignore_diagonal: true
@@ -83,6 +82,7 @@ train:
   checkpointing_full: true
   compile: true
   cudagraphs: false
+  fsdp_reshard_after_forward: true
   cell_augmentation: false
   cell_augmentation_type: hpa
   sharded_eval_checkpoint: true

--- a/dinov3/configs/train/dinov3_vit7b16_pretrain.yaml
+++ b/dinov3/configs/train/dinov3_vit7b16_pretrain.yaml
@@ -6,7 +6,6 @@ MODEL:
 compute_precision:
   param_dtype: bf16
   reduce_dtype: fp32
-  sharding_strategy: SHARD_GRAD_OP
 dino:
   loss_weight: 1.0
   global_ignore_diagonal: true
@@ -55,6 +54,7 @@ train:
   checkpointing_full: false
   compile: true
   cudagraphs: false
+  fsdp_reshard_after_forward: true
   cell_augmentation: false
   cell_augmentation_type: hpa
   sharded_eval_checkpoint: true

--- a/dinov3/configs/train/dinov3_vitl16_lvd1689m_distilled.yaml
+++ b/dinov3/configs/train/dinov3_vitl16_lvd1689m_distilled.yaml
@@ -6,7 +6,6 @@ MODEL:
 compute_precision:
   param_dtype: bf16
   reduce_dtype: fp32
-  sharding_strategy: SHARD_GRAD_OP
 dino:
   loss_weight: 1.0
   global_ignore_diagonal: true
@@ -85,6 +84,7 @@ train:
   checkpointing_full: true
   compile: true
   cudagraphs: false
+  fsdp_reshard_after_forward: true
   cell_augmentation: false
   cell_augmentation_type: hpa
   sharded_eval_checkpoint: false

--- a/dinov3/configs/train/vitl_im1k_lin834.yaml
+++ b/dinov3/configs/train/vitl_im1k_lin834.yaml
@@ -10,7 +10,6 @@ MODEL:
 compute_precision:
   param_dtype: bf16
   reduce_dtype: fp32
-  sharding_strategy: SHARD_GRAD_OP
 dino:
   loss_weight: 1.0
   global_ignore_diagonal: true
@@ -55,6 +54,7 @@ train:
   checkpointing: false
   compile: true
   cudagraphs: false
+  fsdp_reshard_after_forward: true
   cell_augmentation: false
   cell_augmentation_type: hpa
 student:

--- a/dinov3/fsdp/ac_compile_parallelize.py
+++ b/dinov3/fsdp/ac_compile_parallelize.py
@@ -86,40 +86,37 @@ def compile_transformer(cfg, model: nn.Module):
         model.blocks[block_id] = wrap_compile_block(block, cfg.train.cudagraphs, is_backbone_block=True)
 
 
-def fsdp_convnext(fsdp_config: Dict[str, Any], model: nn.Module):
+def fsdp_convnext(fsdp_config: Dict[str, Any], model: nn.Module, reshard_after_forward: bool):
     stages = model.stages
     assert isinstance(stages, nn.ModuleList)
     # FSDP wrap at stage level
     for stage_id, stage in enumerate(stages):
-        stage_reshard: int | bool = True
-        stages[stage_id] = fully_shard(stage, **fsdp_config, reshard_after_forward=stage_reshard)
+        stages[stage_id] = fully_shard(stage, **fsdp_config, reshard_after_forward=reshard_after_forward)
     downsample_layers = model.downsample_layers
     assert isinstance(downsample_layers, nn.ModuleList)
     for dsl_id, dsl in enumerate(downsample_layers):
-        dsl_reshard: int | bool = True
-        downsample_layers[dsl_id] = fully_shard(dsl, **fsdp_config, reshard_after_forward=dsl_reshard)
+        downsample_layers[dsl_id] = fully_shard(dsl, **fsdp_config, reshard_after_forward=reshard_after_forward)
     dsl: FSDPState
     stage: FSDPState
     for dsl, stage in zip(downsample_layers, stages):
         dsl.set_modules_to_forward_prefetch([stage])
         stage.set_modules_to_backward_prefetch([dsl])
-    fully_shard(model, **fsdp_config, reshard_after_forward=True)
+    fully_shard(model, **fsdp_config, reshard_after_forward=reshard_after_forward)
     register_fsdp_forward_method(model, "get_intermediate_layers")
 
 
-def fsdp_transformer(fsdp_config: Dict[str, Any], model: nn.Module):
+def fsdp_transformer(fsdp_config: Dict[str, Any], model: nn.Module, reshard_after_forward: bool):
     # Backbone - FSDP every block
     blocks = model.blocks
     assert isinstance(blocks, nn.ModuleList)
     for block_id, block in enumerate(blocks):
-        block_reshard: int | bool = True
-        blocks[block_id] = fully_shard(block, **fsdp_config, reshard_after_forward=block_reshard)
+        blocks[block_id] = fully_shard(block, **fsdp_config, reshard_after_forward=reshard_after_forward)
     prev_block: FSDPState
     next_block: FSDPState
     for prev_block, next_block in zip(blocks, blocks[1:]):
         prev_block.set_modules_to_forward_prefetch([next_block])
         next_block.set_modules_to_backward_prefetch([prev_block])
-    fully_shard(model, **fsdp_config, reshard_after_forward=True)
+    fully_shard(model, **fsdp_config, reshard_after_forward=reshard_after_forward)
     register_fsdp_forward_method(model, "get_intermediate_layers")
 
 
@@ -185,6 +182,9 @@ def ac_compile_parallelize(
         "bf16": torch.bfloat16,
         "fp32": torch.float32,
     }
+    if not isinstance(cfg.train.fsdp_reshard_after_forward, bool):
+        raise ValueError("`train.fsdp_reshard_after_forward` must be a boolean")
+    reshard_after_forward = cfg.train.fsdp_reshard_after_forward
     mp_policy = MixedPrecisionPolicy(
         param_dtype=DTYPE_MAP[cfg.compute_precision.param_dtype],
         reduce_dtype=DTYPE_MAP[cfg.compute_precision.reduce_dtype],
@@ -201,15 +201,17 @@ def ac_compile_parallelize(
         fsdp_config = {"mesh": world_mesh, "mp_policy": mp_policy}
         for k in model.keys():
             if k == "backbone":
-                ARCH_TYPE_MAP[type(model[k])]["fsdp_fn"](fsdp_config, model[k])
+                ARCH_TYPE_MAP[type(model[k])]["fsdp_fn"](fsdp_config, model[k], reshard_after_forward)
             else:
-                model[k] = fully_shard(model[k], **fsdp_config, reshard_after_forward=True)
+                model[k] = fully_shard(model[k], **fsdp_config, reshard_after_forward=reshard_after_forward)
 
     # 4/ Move to `cuda` device
     for model in all_models:
         model.to_empty(device="cuda")
 
-    # 5/ FSDP2: Reshard immediately after forward for inference-only models
+    # 5/ FSDP2: Intentionally always reshard immediately after forward for inference-only models.
+    # This is independent of `train.fsdp_reshard_after_forward`: inference-only modules do not run
+    # backward/optimizer steps, so we force immediate reshard to keep memory usage predictable.
     for model in inference_only_models:
         for k in model.keys():
             fsdp_state: FSDPState = model[k]._get_fsdp_state()

--- a/dinov3/train/ssl_meta_arch.py
+++ b/dinov3/train/ssl_meta_arch.py
@@ -40,9 +40,6 @@ class SSLMetaArch(nn.Module):
         assert cfg.ibot.separate_head is True
         assert cfg.train.centering == "sinkhorn_knopp"
 
-        # For some reason FULL_SHARD doesn't work
-        assert cfg.compute_precision.sharding_strategy == "SHARD_GRAD_OP"
-
         self.cfg = cfg
 
         student_model_dict = dict()


### PR DESCRIPTION
## Summary

This PR adds an FSDP2-native training knob:
- `train.fsdp_reshard_after_forward` (bool, default `true`)

and wires it through the SSL training FSDP wrapping path.

## Why

Previously, `compute_precision.sharding_strategy` existed in configs but did not control FSDP wrapping behavior:
- all relevant `fully_shard(...)` calls in `dinov3/fsdp/ac_compile_parallelize.py` were hardcoded with `reshard_after_forward=True`
- `ssl_meta_arch.py` only had an assert on `SHARD_GRAD_OP`, but no behavioral mapping from config to FSDP2

So effective behavior was fixed regardless of that config key.

## Changes

- Add `train.fsdp_reshard_after_forward` to default/train configs.
- Remove `compute_precision.sharding_strategy` from default/train yaml configs.
- Use `cfg.train.fsdp_reshard_after_forward` for SSL training FSDP wrapping in `ac_compile_parallelize.py`.
- Keep intentional always-reshard behavior for inference-only models and document it inline.
- Remove legacy assert in `ssl_meta_arch.py`.
- Add config migration handling in `configs/config.py`:
  - if `compute_precision.sharding_strategy` is present in user config/CLI overrides, warn and remove it before strict merge.

## Quick manual verification

```bash
.venv/bin/python - <<'PY'
from dinov3.configs.config import DinoV3SetupArgs, get_cfg_from_args

args = DinoV3SetupArgs(
    config_file='dinov3/configs/ssl_default_config.yaml',
    output_dir=None,
    opts=[
        'compute_precision.sharding_strategy=SHARD_GRAD_OP',
        'train.fsdp_reshard_after_forward=false',
    ],
)
cfg = get_cfg_from_args(args, strict=True)
print('fsdp_reshard_after_forward=', cfg.train.fsdp_reshard_after_forward)
print('has_legacy_key=', 'sharding_strategy' in cfg.compute_precision)
PY
```

Expected output:
- deprecation warning for `compute_precision.sharding_strategy`
- `fsdp_reshard_after_forward= False`
- `has_legacy_key= False`

## Notes

No automated tests were added (none are currently present for this area in the repo).
