### PR TITLE
Fix newer numpy integer out of bounds issues in ImageNet dataset

### DIFF
--- a/dinov3/data/datasets/image_net.py
+++ b/dinov3/data/datasets/image_net.py
@@ -233,7 +233,7 @@ class ImageNet(ExtendedVisionDataset):
                     old_percent = percent
 
                 actual_index = index + 1
-                class_index = np.uint32(-1)
+                class_index = np.uint32(np.iinfo(np.uint32).max)
                 class_id, class_name = "", ""
                 entries_array[index] = (actual_index, class_index, class_id, class_name)
         else:


### PR DESCRIPTION
For NumPy>=2.0 `np.uint32(-1)` results in an OverFlowError as -1 is out of bounds for uint32. Older NumPy versions would silently wrap it to `4294967295`(the maximum of uint32). This new line should fix it while achieving the same result