### PR TITLE
Re-enable cycle GC in training loop to prevent worker anon RSS leak

### DIFF
--- a/dinov3/train/train.py
+++ b/dinov3/train/train.py
@@ -431,8 +431,15 @@ def do_train(cfg, model, resume=False):
     logger.info("Starting training from iteration %d", start_iter)
     metrics_file = os.path.join(cfg.train.output_dir, "training_metrics.json")
     metric_logger = MetricLogger(delimiter="  ", output_file=metrics_file)
-    # Manual garbage collection
-    gc.disable()
+    # Keep automatic cycle GC enabled. Disabling it interacts with
+    # `torchvision.transforms.v2`, whose `pytree.tree_flatten` machinery creates
+    # short-lived reference cycles; with no cycle collector running, the cycles
+    # accumulate, holding tensor storage refs and shared-memory FDs, and worker
+    # anon RSS grows linearly (~1.25 GB/h/worker @ num_workers=16 observed in
+    # practice → multi-node OOM around 18h into training).
+    # The periodic, rank-synchronized `gc.collect()` below is kept for predictable
+    # cross-rank GC pauses; what is removed is the automatic-collector disable.
+    # Refs: #242, pytorch/vision#9242.
     gc.collect()
 
     # Training loop


### PR DESCRIPTION
## Summary

`gc.disable()` in `do_train()` interacts with `torchvision.transforms.v2`: its `pytree.tree_flatten` machinery creates short-lived reference cycles, and with no cycle collector running they accumulate, holding tensor storage refs and shared-memory FDs. Worker anon RSS grows linearly at ~1.25 GB/h/worker (num_workers=16 observed in practice), leading to multi-node OOM around the 18-hour mark.

This PR removes the `gc.disable()` call; the periodic rank-synchronized `gc.collect()` further down the loop is kept untouched.

## Evidence

Controlled A/B benchmark — 1000 iters, num_workers=4 DataLoader, per-iter `/proc/<pid>/status` `RssAnon` sampling on each worker, two fresh subprocesses for isolated gc state:

| Condition                  | Workers RssAnon growth |
|----------------------------|------------------------|
| `gc.disable()` (current)   | ~3.4 MB/iter           |
| Cycle GC enabled (this PR) | ~0.01 MB/iter          |

~300× reduction. The residual ~0.01 MB/iter is allocator-level drift (long flat plateaus, not monotonic growth), not a leak signature.

Iter-time impact: mean within ±0.05% between conditions — re-enabling the automatic cycle collector does not measurably slow training in this benchmark.

## Reproduces #242

Same leak as #242 with two independent community reports. Mechanism:

```
torchvision.transforms.v2 → pytree.tree_flatten → ref cycles
              ↓ (with gc.disable: never collected)
              ↓ tensor storage refs accumulate
              ↓ shared-memory FDs not munmap'd
              ↓ anon RSS grows
```

## Cross-repo reference

[pytorch/vision#9242](https://github.com/pytorch/vision/issues/9242) contains direct `tracemalloc` evidence pinpointing the growing allocations to `torch/utils/_pytree.py` called from `torchvision/transforms/v2/_transform.py`. The reporter also notes v2 → v1 swap *alleviates but does not eliminate* the leak in their setup — likely because they hit a second known leak path ([pytorch/vision#6437](https://github.com/pytorch/vision/issues/6437), GaussianBlur with variable-size inputs). DINOv3's pipeline runs `RandomResizedCrop` before `GaussianBlur` (uniform tensors), so #6437 does not apply here.

## Alternative considered

Switching `dinov3/data/augmentations.py` and `dinov3/data/transforms.py` from `torchvision.transforms.v2` to `v1`. Rejected as much more invasive (~30 lines, semantic differences in `v2.ToImage` vs `v1.ToTensor`, antialias defaults, PIL handling) for the same observable end-state.

## Notes

- The periodic manual `gc.collect()` below the changed line preserves the original intent (predictable, rank-synchronized GC pauses for distributed training).
- Fix is a single-line deletion (plus a comment explaining why).