### PR TITLE
[eval] Make inference device explicitly configurable

### DIFF
--- a/dinov3/eval/data.py
+++ b/dinov3/eval/data.py
@@ -230,14 +230,21 @@ def create_train_dataset_dict(
 
 
 def extract_features_for_dataset_dict(
-    model, dataset_dict: dict[int, dict[int, Any]], batch_size: int, num_workers: int, gather_on_cpu=False
+    model,
+    dataset_dict: dict[int, dict[int, Any]],
+    batch_size: int,
+    num_workers: int,
+    gather_on_cpu=False,
+    device=None,
 ) -> dict[int, dict[str, torch.Tensor]]:
     """
     Extract features for each subset of dataset in the context of few-shot evaluations
     """
     few_shot_data_dict: dict[int, dict[str, torch.Tensor]] = {}
     for try_n, dataset in dataset_dict.items():
-        features, labels = extract_features(model, dataset, batch_size, num_workers, gather_on_cpu=gather_on_cpu)
+        features, labels = extract_features(
+            model, dataset, batch_size, num_workers, gather_on_cpu=gather_on_cpu, device=device
+        )
         few_shot_data_dict[try_n] = {"train_features": features, "train_labels": labels}
     return few_shot_data_dict
 

--- a/dinov3/eval/depth/config.py
+++ b/dinov3/eval/depth/config.py
@@ -128,6 +128,8 @@ class DepthConfig:
     result_config: ResultConfig = field(default_factory=ResultConfig)
     load_from: str | None = None  # path to .pt checkpoint to resume training from
     output_dir: str = ""
+    # Target device for inference; None selects CUDA when available, else CPU
+    device: str | None = None
 
 
 def make_depth_train_transforms_from_config(config: DepthConfig):

--- a/dinov3/eval/depth/models/__init__.py
+++ b/dinov3/eval/depth/models/__init__.py
@@ -9,6 +9,7 @@ from typing import Any
 import torch
 from dinov3.eval.depth.checkpoint_utils import load_checkpoint
 from dinov3.eval.depth.utils import create_chmv2_mixlog_bins, create_outputs_with_chmv2_mixlog_norm
+from dinov3.eval.setup import get_autocast_device_type, resolve_device
 
 from .dpt_head import DPTHead
 from .linear_head import LinearHead
@@ -167,6 +168,7 @@ class Depther(torch.nn.Module):
         bins_strategy: str = "linear",
         norm_strategy: str = "linear",
         autocast_dtype: torch.dtype = torch.float32,
+        device=None,
     ):
         super().__init__()
         self.encoder = encoder
@@ -178,12 +180,15 @@ class Depther(torch.nn.Module):
             bins_strategy=bins_strategy,
             norm_strategy=norm_strategy,
         )
-        if torch.cuda.is_available():
-            self.autocast_ctx = partial(torch.autocast, device_type="cuda", dtype=autocast_dtype, enabled=True)
-            self.encoder.cuda()
-            self.decoder.cuda()
-        else:
-            self.autocast_ctx = partial(torch.autocast, device_type="cpu", enabled=True)
+        device = resolve_device(device)
+        self.encoder.to(device)
+        self.decoder.to(device)
+        self.autocast_ctx = partial(
+            torch.autocast,
+            device_type=get_autocast_device_type(device),
+            dtype=autocast_dtype,
+            enabled=True,
+        )
 
     def forward(self, x):
         with self.autocast_ctx():
@@ -203,6 +208,7 @@ def build_depther(
     adapt_to_patch_size: PatchSizeAdaptationStrategy = PatchSizeAdaptationStrategy.CENTER_PADDING,
     head_type: str = "dpt",
     autocast_dtype: torch.dtype = torch.float32,
+    device=None,
     # depth args
     min_depth: float = 0.001,
     max_depth: float = 10.0,
@@ -234,6 +240,7 @@ def build_depther(
         bins_strategy=bins_strategy,
         norm_strategy=norm_strategy,
         autocast_dtype=autocast_dtype,
+        device=device,
     )
     depther.eval()
     return depther
@@ -244,6 +251,7 @@ def make_depther_from_config(
     config: DecoderConfig,
     checkpoint_path: str | None = None,
     autocast_dtype: torch.dtype = torch.float32,
+    device=None,
 ) -> Depther:
     depther = build_depther(
         backbone,
@@ -255,6 +263,7 @@ def make_depther_from_config(
         adapt_to_patch_size=config.adapt_to_patch_size,
         head_type=config.type,
         autocast_dtype=autocast_dtype,
+        device=device,
         min_depth=config.min_depth,
         max_depth=config.max_depth,
         bins_strategy=config.bins_strategy,

--- a/dinov3/eval/depth/run.py
+++ b/dinov3/eval/depth/run.py
@@ -20,7 +20,7 @@ from dinov3.eval.depth.models import make_depther_from_config
 from dinov3.eval.depth.train import train_model_with_backbone
 
 from dinov3.eval.helpers import args_dict_to_dataclass, cli_parser, write_results
-from dinov3.eval.setup import load_model_and_context
+from dinov3.eval.setup import load_model_and_context, resolve_device
 from dinov3.run.init import job_context
 from dinov3.hub.depthers import _get_depther_config, dinov3_vit7b16_dd
 
@@ -90,8 +90,10 @@ def benchmark_launcher(eval_args: dict[str, Any]) -> dict[str, Any]:
     OmegaConf.save(config=depth_config, f=os.path.join(output_dir, "depth_config.yaml"))
 
     config_autocast_dtype = depth_config.model_dtype.autocast_dtype if depth_config.model_dtype is not None else None
+    model_device = depth_config.model.device if depth_config.model is not None else None
+    device = resolve_device(model_device if model_device is not None else depth_config.device)
     if depth_config.load_from == "dinov3_vit7b16_dd":
-        with torch.device("cuda" if torch.cuda.is_available() else "cpu"):
+        with torch.device(device):
             autocast_dtype = config_autocast_dtype or torch.float32
             # override config parameters with those of the pretrained depther
             depther_config = _get_depther_config("dinov3_vit7b16")
@@ -105,12 +107,16 @@ def benchmark_launcher(eval_args: dict[str, Any]) -> dict[str, Any]:
             depther = dinov3_vit7b16_dd(
                 pretrained=True,
                 autocast_dtype=autocast_dtype,
+                device=device,
             )
     else:
-        with torch.device("cuda" if torch.cuda.is_available() else "cpu"):
+        if depth_config.model is not None and depth_config.model.device is None:
+            depth_config.model.device = str(device)
+        with torch.device(device):
             assert depth_config.model is not None
             model, model_context = load_model_and_context(depth_config.model, output_dir=output_dir)
             autocast_dtype = config_autocast_dtype or model_context["autocast_dtype"]
+            device = model_context["device"]
 
         if depth_config.load_from:
             depther = make_depther_from_config(
@@ -118,6 +124,7 @@ def benchmark_launcher(eval_args: dict[str, Any]) -> dict[str, Any]:
                 config=depth_config.decoder_head,
                 checkpoint_path=depth_config.load_from,
                 autocast_dtype=autocast_dtype,
+                device=device,
             )
             logger.info(f"Depth config:\n {OmegaConf.to_yaml(depth_config)}")
         else:

--- a/dinov3/eval/knn.py
+++ b/dinov3/eval/knn.py
@@ -35,7 +35,7 @@ from dinov3.eval.data import (
 )
 from dinov3.eval.helpers import args_dict_to_dataclass, cli_parser, write_results
 from dinov3.eval.metrics import ClassificationMetricType, build_classification_metric
-from dinov3.eval.setup import ModelConfig, load_model_and_context
+from dinov3.eval.setup import ModelConfig, get_autocast_device_type, load_model_and_context, resolve_device
 from dinov3.eval.utils import ModelWithNormalize, average_metrics, evaluate
 from dinov3.eval.utils import save_results as default_save_results_func
 from dinov3.run.init import job_context
@@ -235,11 +235,12 @@ def eval_knn(
     knn_config: TrainConfig,
     num_classes: int,
     save_results_func=None,
+    device=None,
 ):
     logger.info("Start the k-NN classification.")
     eval_metrics_dict: Dict[int, Dict[int, Dict[str, float]]] = {}  # {k: {try: {metric_name: metric_value}}}
     save_results = save_results_func is not None
-    device = torch.cuda.current_device()
+    device = resolve_device(device)
     partial_knn_module = partial(
         KnnModule,
         device=device,
@@ -302,9 +303,10 @@ def _log_and_format_results_dict(input_results_dict, few_shot_n_tries: int) -> D
     return results_dict
 
 
-def eval_knn_with_model(*, model: torch.nn.Module, autocast_dtype, config: KnnEvalConfig):
+def eval_knn_with_model(*, model: torch.nn.Module, autocast_dtype, config: KnnEvalConfig, device=None):
     start = time.time()
     cudnn.benchmark = True
+    device = resolve_device(device)
 
     # Setting up datasets
     transform = make_transform(config.transform)
@@ -332,10 +334,15 @@ def eval_knn_with_model(*, model: torch.nn.Module, autocast_dtype, config: KnnEv
         save_results_func = partial(default_save_results_func, output_dir=config.output_dir)
 
     model = ModelWithNormalize(model)
-    with torch.autocast("cuda", dtype=autocast_dtype):
+    with torch.autocast(get_autocast_device_type(device), dtype=autocast_dtype):
         logger.info("Extracting features for train set...")
         train_data_dict = extract_features_for_dataset_dict(
-            model, train_dataset_dict, config.train.batch_size, config.train.num_workers, gather_on_cpu=True
+            model,
+            train_dataset_dict,
+            config.train.batch_size,
+            config.train.num_workers,
+            gather_on_cpu=True,
+            device=device,
         )
         results_dict_knn = eval_knn(
             model=model,
@@ -345,6 +352,7 @@ def eval_knn_with_model(*, model: torch.nn.Module, autocast_dtype, config: KnnEv
             knn_config=config.train,
             num_classes=num_classes,
             save_results_func=save_results_func,
+            device=device,
         )
     results_dict = _log_and_format_results_dict(results_dict_knn, config.few_shot.n_tries)
 
@@ -365,7 +373,10 @@ def benchmark_launcher(eval_args: dict[str, object]) -> dict[str, Any]:
     dataclass_config, output_dir = args_dict_to_dataclass(eval_args=eval_args, config_dataclass=KnnEvalConfig)
     model, model_context = load_model_and_context(dataclass_config.model, output_dir=output_dir)
     results_dict = eval_knn_with_model(
-        model=model, config=dataclass_config, autocast_dtype=model_context["autocast_dtype"]
+        model=model,
+        config=dataclass_config,
+        autocast_dtype=model_context["autocast_dtype"],
+        device=model_context["device"],
     )
     write_results(results_dict, output_dir, RESULTS_FILENAME)
     return results_dict

--- a/dinov3/eval/linear.py
+++ b/dinov3/eval/linear.py
@@ -38,7 +38,7 @@ from dinov3.data.transforms import (
 from dinov3.eval.data import create_train_dataset_dict, get_num_classes, pad_multilabel_and_collate
 from dinov3.eval.helpers import args_dict_to_dataclass, cli_parser, write_results
 from dinov3.eval.metrics import ClassificationMetricType, build_classification_metric
-from dinov3.eval.setup import ModelConfig, load_model_and_context
+from dinov3.eval.setup import ModelConfig, get_autocast_device_type, load_model_and_context, resolve_device
 from dinov3.eval.utils import LossType, ModelWithIntermediateLayers, average_metrics, evaluate
 from dinov3.eval.utils import save_results as default_save_results_func
 from dinov3.logging import MetricLogger, SmoothedValue
@@ -209,7 +209,8 @@ def scale_lr(learning_rates, batch_size):
     return learning_rates * (batch_size * distributed.get_world_size()) / 256.0
 
 
-def setup_linear_classifiers(sample_output, n_last_blocks_list, learning_rates, batch_size, num_classes=1000):
+def setup_linear_classifiers(sample_output, n_last_blocks_list, learning_rates, batch_size, num_classes=1000, device=None):
+    device = resolve_device(device)
     linear_classifiers_dict = nn.ModuleDict()
     optim_param_groups = []
     for n in n_last_blocks_list:
@@ -220,7 +221,7 @@ def setup_linear_classifiers(sample_output, n_last_blocks_list, learning_rates, 
                 linear_classifier = LinearClassifier(
                     out_dim, use_n_blocks=n, use_avgpool=avgpool, num_classes=num_classes
                 )
-                linear_classifier = linear_classifier.cuda()
+                linear_classifier = linear_classifier.to(device)
                 linear_classifiers_dict[
                     f"classifier_{n}_blocks_avgpool_{avgpool}_lr_{lr:.5f}".replace(".", "_")
                 ] = linear_classifier
@@ -280,6 +281,7 @@ class Evaluator:
     metrics_file_path: str
     training_num_classes: int
     save_results_func: Optional[Callable]
+    device: torch.device = field(default_factory=lambda: resolve_device())
 
     def __post_init__(self):
         self.data_loader, self.class_mapping = make_eval_data_loader(
@@ -316,7 +318,7 @@ class Evaluator:
             self.data_loader,
             postprocessors,
             metrics,
-            torch.cuda.current_device(),
+            self.device,
             accumulate_results=accumulate_results,
         )
 
@@ -388,7 +390,9 @@ def make_evaluators(
     metrics_file_path: str,
     training_num_classes: int,
     save_results_func: Optional[Callable],
+    device=None,
 ):
+    device = resolve_device(device)
     test_metric_types = eval_config.test_metric_types
     if len(test_metric_types) == 0:
         test_metric_types = (val_metric_type,) * len(eval_config.test_datasets)
@@ -404,6 +408,7 @@ def make_evaluators(
             metrics_file_path=metrics_file_path,
             training_num_classes=training_num_classes,
             save_results_func=save_results_func,
+            device=device,
         )
         for dataset_str, metric_type in zip(
             (val_dataset,) + tuple(eval_config.test_datasets),
@@ -419,6 +424,7 @@ def setup_linear_training(
     sample_output: torch.Tensor,
     training_num_classes: int,
     checkpoint_output_dir: str,
+    device=None,
 ):
     linear_classifiers, optim_param_groups = setup_linear_classifiers(
         sample_output,
@@ -426,6 +432,7 @@ def setup_linear_training(
         config.learning_rates,
         config.batch_size,
         training_num_classes,
+        device=device,
     )
     max_iter = config.epochs * config.epoch_length
     optimizer = config.optimizer_type.get_optimizer(optim_param_groups=optim_param_groups)
@@ -472,12 +479,15 @@ def train_linear_classifiers(
     training_num_classes: int,
     val_evaluator: Evaluator,
     checkpoint_output_dir: str,
+    device=None,
 ):
+    device = resolve_device(device)
     (linear_classifiers, start_iter, max_iter, criterion, optimizer, scheduler, best_accuracy,) = setup_linear_training(
         config=train_config,
-        sample_output=feature_model(train_dataset[0][0].unsqueeze(0).cuda()),
+        sample_output=feature_model(train_dataset[0][0].unsqueeze(0).to(device)),
         training_num_classes=training_num_classes,
         checkpoint_output_dir=checkpoint_output_dir,
+        device=device,
     )
     checkpoint_period = train_config.save_checkpoint_iterations or train_config.epoch_length
     eval_period = train_config.eval_period_iterations or train_config.epoch_length
@@ -507,8 +517,8 @@ def train_linear_classifiers(
         max_iter,
         start_iter,
     ):
-        data = data.cuda(non_blocking=True)
-        labels = labels.cuda(non_blocking=True)
+        data = data.to(device, non_blocking=True)
+        labels = labels.to(device, non_blocking=True)
 
         features = feature_model(data)
         outputs = linear_classifiers(features)
@@ -528,7 +538,8 @@ def train_linear_classifiers(
 
         # log
         if iteration % 10 == 0:
-            torch.cuda.synchronize()
+            if device.type == "cuda":
+                torch.cuda.synchronize()
             metric_logger.update(loss=loss.item())
             metric_logger.update(lr=optimizer.param_groups[0]["lr"])
 
@@ -584,9 +595,10 @@ def make_train_dataset(train_dataset: str, transform_config: TransformConfig):
     return make_dataset(dataset_str=train_dataset, transform=train_transform)
 
 
-def eval_linear_with_model(*, model: torch.nn.Module, autocast_dtype, config: LinearEvalConfig):
+def eval_linear_with_model(*, model: torch.nn.Module, autocast_dtype, config: LinearEvalConfig, device=None):
     start = time.time()
     cudnn.benchmark = True
+    device = resolve_device(device)
 
     train_dataset = make_train_dataset(config.train.dataset, config.transform)
     training_num_classes = get_num_classes(train_dataset)
@@ -597,7 +609,12 @@ def eval_linear_with_model(*, model: torch.nn.Module, autocast_dtype, config: Li
         few_shot_n_tries=config.few_shot.n_tries,
     )
     n_last_blocks = max(config.train.n_last_blocks_list)
-    autocast_ctx = partial(torch.autocast, device_type="cuda", enabled=True, dtype=autocast_dtype)
+    autocast_ctx = partial(
+        torch.autocast,
+        device_type=get_autocast_device_type(device),
+        enabled=True,
+        dtype=autocast_dtype,
+    )
     feature_model = ModelWithIntermediateLayers(model, n_last_blocks, autocast_ctx)
 
     save_results_func = None
@@ -613,6 +630,7 @@ def eval_linear_with_model(*, model: torch.nn.Module, autocast_dtype, config: Li
         metrics_file_path=metrics_file_path,
         training_num_classes=training_num_classes,
         save_results_func=save_results_func,
+        device=device,
     )
     results_dict = {}
     checkpoint_output_dirs: list = []
@@ -632,6 +650,7 @@ def eval_linear_with_model(*, model: torch.nn.Module, autocast_dtype, config: Li
             training_num_classes=training_num_classes,
             val_evaluator=val_evaluator,
             checkpoint_output_dir=checkpoint_output_dir,
+            device=device,
         )
         checkpoint_output_dirs.append(checkpoint_output_dir)
         results_dict[_try] = val_evaluator.evaluate_and_maybe_save(
@@ -669,7 +688,10 @@ def benchmark_launcher(eval_args: dict[str, object]) -> dict[str, Any]:
     dataclass_config, output_dir = args_dict_to_dataclass(eval_args=eval_args, config_dataclass=LinearEvalConfig)
     model, model_context = load_model_and_context(dataclass_config.model, output_dir=output_dir)
     results_dict = eval_linear_with_model(
-        model=model, config=dataclass_config, autocast_dtype=model_context["autocast_dtype"]
+        model=model,
+        config=dataclass_config,
+        autocast_dtype=model_context["autocast_dtype"],
+        device=model_context["device"],
     )
     write_results(results_dict, output_dir, RESULTS_FILENAME)
     return results_dict

--- a/dinov3/eval/log_regression.py
+++ b/dinov3/eval/log_regression.py
@@ -30,7 +30,7 @@ from dinov3.eval.data import (
 )
 from dinov3.eval.helpers import args_dict_to_dataclass, cli_parser, write_results
 from dinov3.eval.metrics import ClassificationMetricType, build_classification_metric
-from dinov3.eval.setup import ModelConfig, load_model_and_context
+from dinov3.eval.setup import ModelConfig, get_autocast_device_type, load_model_and_context, resolve_device
 from dinov3.eval.utils import average_metrics, evaluate, extract_features
 from dinov3.eval.utils import save_results as default_save_results_func
 from dinov3.run.init import job_context
@@ -142,7 +142,7 @@ class LogRegModule(nn.Module):
         self.estimator.fit(train_features, train_labels)
 
 
-def evaluate_logreg_model(*, logreg_model, test_metric, test_data_loader, save_results_func=None):
+def evaluate_logreg_model(*, logreg_model, test_metric, test_data_loader, save_results_func=None, device=None):
     key = "metrics"  # We need only one key as we have only one metric
     postprocessors, metrics = {key: logreg_model}, {key: test_metric}
     _, eval_metrics, accumulated_results = evaluate(
@@ -150,7 +150,7 @@ def evaluate_logreg_model(*, logreg_model, test_metric, test_data_loader, save_r
         test_data_loader,
         postprocessors,
         metrics,
-        torch.cuda.current_device(),
+        resolve_device(device),
         accumulate_results=save_results_func is not None,
     )
     if save_results_func is not None:
@@ -302,21 +302,21 @@ def make_train_val_datasets(train_config: TrainConfig, few_shot_config: FewShotC
     return train_dataset_dict, val_dataset, num_classes
 
 
-def make_test_dataset_and_data_loader(model, config: EvalConfig, transform, gather_on_cpu: bool):
+def make_test_dataset_and_data_loader(model, config: EvalConfig, transform, gather_on_cpu: bool, device=None):
     test_dataset = make_dataset(
         dataset_str=config.test_dataset,
         transform=transform,
         target_transform=get_target_transform(config.test_dataset),
     )
     test_features, test_labels = extract_features(
-        model, test_dataset, config.batch_size, config.num_workers, gather_on_cpu=gather_on_cpu
+        model, test_dataset, config.batch_size, config.num_workers, gather_on_cpu=gather_on_cpu, device=device
     )
     assert isinstance(config.batch_size, int)  # eval batch size has been replaced by train batch size if None
     test_data_loader = make_logreg_data_loader(config.batch_size, config.num_workers, test_features, test_labels)
     return test_dataset, test_data_loader
 
 
-def eval_log_regression_with_model(*, model: torch.nn.Module, autocast_dtype, config: LogregEvalConfig):
+def eval_log_regression_with_model(*, model: torch.nn.Module, autocast_dtype, config: LogregEvalConfig, device=None):
     """
     Implements the "standard" process for log regression evaluation:
     The value of C is chosen by training on train_dataset and evaluating on
@@ -327,6 +327,7 @@ def eval_log_regression_with_model(*, model: torch.nn.Module, autocast_dtype, co
     """
     start = time.time()
     cudnn.benchmark = True
+    device = resolve_device(device)
 
     transform = make_transform(config.transform)
     config.eval.batch_size = config.eval.batch_size or config.train.batch_size  # use train batch size for eval if None
@@ -335,20 +336,33 @@ def eval_log_regression_with_model(*, model: torch.nn.Module, autocast_dtype, co
     train_dataset_dict, val_dataset, num_classes = make_train_val_datasets(config.train, config.few_shot, transform)
 
     # Extracting features
-    with torch.autocast("cuda", dtype=autocast_dtype):
+    with torch.autocast(get_autocast_device_type(device), dtype=autocast_dtype):
         gather_on_cpu = torch.device(config.train.train_features_device) == _CPU_DEVICE
         train_data_dict = extract_features_for_dataset_dict(
-            model, train_dataset_dict, config.train.batch_size, config.train.num_workers, gather_on_cpu=gather_on_cpu
+            model,
+            train_dataset_dict,
+            config.train.batch_size,
+            config.train.num_workers,
+            gather_on_cpu=gather_on_cpu,
+            device=device,
         )
         logger.info("Choosing hyperparameters on the val dataset")
         val_features, val_labels = extract_features(
-            model, val_dataset, config.train.batch_size, config.train.num_workers, gather_on_cpu=gather_on_cpu
+            model,
+            val_dataset,
+            config.train.batch_size,
+            config.train.num_workers,
+            gather_on_cpu=gather_on_cpu,
+            device=device,
         )
-        test_dataset, test_data_loader = make_test_dataset_and_data_loader(model, config.eval, transform, gather_on_cpu)
+        test_dataset, test_data_loader = make_test_dataset_and_data_loader(
+            model, config.eval, transform, gather_on_cpu, device=device
+        )
 
     # Moves the model to cpu in-place. Deleting the variable would only delete a reference and not free any space.
     model.cpu()  # all features are extracted, we won't use the backbone anymore
-    torch.cuda.empty_cache()
+    if device.type == "cuda":
+        torch.cuda.empty_cache()
 
     # Setting up metrics
     val_metric = build_classification_metric(config.train.val_metric_type, num_classes=num_classes, dataset=val_dataset)
@@ -381,6 +395,7 @@ def eval_log_regression_with_model(*, model: torch.nn.Module, autocast_dtype, co
             test_metric=test_metric.clone(),
             test_data_loader=test_data_loader,
             save_results_func=split_results_saver,
+            device=device,
         )
         results_dict[_try] = {k: v.item() * 100.0 for k, v in eval_metrics["metrics"].items()}
 
@@ -403,7 +418,10 @@ def benchmark_launcher(eval_args: dict[str, object]) -> dict[str, Any]:
     dataclass_config, output_dir = args_dict_to_dataclass(eval_args=eval_args, config_dataclass=LogregEvalConfig)
     model, model_context = load_model_and_context(dataclass_config.model, output_dir=output_dir)
     results_dict = eval_log_regression_with_model(
-        model=model, config=dataclass_config, autocast_dtype=model_context["autocast_dtype"]
+        model=model,
+        config=dataclass_config,
+        autocast_dtype=model_context["autocast_dtype"],
+        device=model_context["device"],
     )
     write_results(results_dict, output_dir, RESULTS_FILENAME)
     return results_dict

--- a/dinov3/eval/segmentation/config.py
+++ b/dinov3/eval/segmentation/config.py
@@ -124,3 +124,5 @@ class SegmentationConfig:
     # Additional Parameters
     output_dir: str | None = None
     load_from: str | None = None  # path to .pt checkpoint to resume training from or evaluate from
+    # Target device for inference; None selects CUDA when available, else CPU
+    device: str | None = None

--- a/dinov3/eval/segmentation/eval.py
+++ b/dinov3/eval/segmentation/eval.py
@@ -17,6 +17,7 @@ from dinov3.eval.segmentation.metrics import (
 )
 from dinov3.eval.segmentation.models import build_segmentation_decoder
 from dinov3.eval.segmentation.transforms import make_segmentation_eval_transforms
+from dinov3.eval.setup import resolve_device
 from dinov3.hub.segmentors import dinov3_vit7b16_ms
 from dinov3.logging import MetricLogger
 
@@ -95,6 +96,9 @@ def test_segmentation(backbone, config):
             num_classes=config.decoder_head.num_classes,
             autocast_dtype=config.model_dtype.autocast_dtype,
             dropout=config.decoder_head.dropout,
+            device=resolve_device(
+                config.model.device if config.model is not None and config.model.device is not None else config.device
+            ),
         )
         state_dict = torch.load(config.load_from, map_location="cpu")["model"]
         _, _ = segmentation_model.load_state_dict(state_dict, strict=False)

--- a/dinov3/eval/segmentation/models/__init__.py
+++ b/dinov3/eval/segmentation/models/__init__.py
@@ -11,6 +11,7 @@ import torch
 from dinov3.eval.segmentation.models.backbone.dinov3_adapter import DINOv3_Adapter
 from dinov3.eval.segmentation.models.heads.linear_head import LinearHead
 from dinov3.eval.segmentation.models.heads.mask2former_head import Mask2FormerHead
+from dinov3.eval.setup import get_autocast_device_type, resolve_device
 from dinov3.eval.utils import ModelWithIntermediateLayers
 
 
@@ -81,9 +82,16 @@ def build_segmentation_decoder(
     num_classes=150,
     dropout=0.1,
     autocast_dtype=torch.float32,
+    device=None,
 ):
     backbone_indices_to_use = _get_backbone_out_indices(backbone_model, backbone_out_layers)
-    autocast_ctx = partial(torch.autocast, device_type="cuda", enabled=True, dtype=autocast_dtype)
+    device = resolve_device(device)
+    autocast_ctx = partial(
+        torch.autocast,
+        device_type=get_autocast_device_type(device),
+        enabled=True,
+        dtype=autocast_dtype,
+    )
     if decoder_type == "m2f":
         backbone_model = DINOv3_Adapter(
             backbone_model,

--- a/dinov3/eval/segmentation/run.py
+++ b/dinov3/eval/segmentation/run.py
@@ -52,6 +52,8 @@ def benchmark_launcher(eval_args: dict[str, object]) -> dict[str, Any]:
         dataclass_config, output_dir = args_dict_to_dataclass(eval_args=eval_args, config_dataclass=SegmentationConfig)
     backbone = None
     if dataclass_config.model:
+        if dataclass_config.model.device is None and dataclass_config.device is not None:
+            dataclass_config.model.device = dataclass_config.device
         backbone, _ = load_model_and_context(dataclass_config.model, output_dir=output_dir)
     else:
         assert dataclass_config.load_from == "dinov3_vit7b16_ms"

--- a/dinov3/eval/segmentation/train.py
+++ b/dinov3/eval/segmentation/train.py
@@ -20,6 +20,7 @@ from dinov3.eval.segmentation.metrics import SEGMENTATION_METRICS
 from dinov3.eval.segmentation.models import build_segmentation_decoder
 from dinov3.eval.segmentation.schedulers import build_scheduler
 from dinov3.eval.segmentation.transforms import make_segmentation_eval_transforms, make_segmentation_train_transforms
+from dinov3.eval.setup import get_autocast_device_type, resolve_device
 from dinov3.logging import MetricLogger, SmoothedValue
 
 logger = logging.getLogger("dinov3")
@@ -116,7 +117,11 @@ def train_step(
     optimizer.zero_grad(set_to_none=True)
 
     # b) forward pass
-    with torch.autocast("cuda", dtype=model_dtype, enabled=True if model_dtype is not None else False):
+    with torch.autocast(
+        get_autocast_device_type(device),
+        dtype=model_dtype,
+        enabled=True if model_dtype is not None else False,
+    ):
         pred = segmentation_model(batch_img)  # B x num_classes x h x w
         gt = torch.squeeze(gt).long()  # Adapt gt dimension to enable loss calculation
 
@@ -157,6 +162,9 @@ def train_segmentation(
         num_classes=config.decoder_head.num_classes,
         autocast_dtype=config.model_dtype.autocast_dtype,
         dropout=config.decoder_head.dropout,
+        device=resolve_device(
+            config.model.device if config.model is not None and config.model.device is not None else config.device
+        ),
     )
     global_device = distributed.get_rank()
     local_device = torch.cuda.current_device()

--- a/dinov3/eval/setup.py
+++ b/dinov3/eval/setup.py
@@ -21,6 +21,8 @@ class ModelConfig:
     pretrained_weights: str | None = None
     # Loading a DINOv3 or v2 model from torch.hub
     dino_hub: str | None = None
+    # Target device for eval; None selects CUDA when available, else CPU
+    device: str | None = None
 
 
 class BaseModelContext(TypedDict):
@@ -29,6 +31,21 @@ class BaseModelContext(TypedDict):
     """
 
     autocast_dtype: torch.dtype  # default could be torch.float
+    device: torch.device
+
+
+def resolve_device(device: str | torch.device | None = None) -> torch.device:
+    if device is not None:
+        return torch.device(device)
+    if torch.cuda.is_available():
+        return torch.device("cuda")
+    return torch.device("cpu")
+
+
+def get_autocast_device_type(device: str | torch.device | None = None) -> str:
+    """Return a torch.autocast-compatible device_type string."""
+    resolved = resolve_device(device)
+    return "cuda" if resolved.type == "cuda" else "cpu"
 
 
 def load_model_and_context(model_config: ModelConfig, output_dir: str) -> tuple[torch.nn.Module, BaseModelContext]:
@@ -41,15 +58,17 @@ def load_model_and_context(model_config: ModelConfig, output_dir: str) -> tuple[
         else:
             raise ValueError
         model = torch.hub.load(f"facebookresearch/{repo}", model_config.dino_hub)
-        base_model_context = BaseModelContext(autocast_dtype=torch.float)
+        base_model_context = BaseModelContext(autocast_dtype=torch.float, device=resolve_device(model_config.device))
     else:
         model, base_model_context = setup_and_build_model(
             config_file=model_config.config_file,
             pretrained_weights=model_config.pretrained_weights,
             output_dir=output_dir,
+            device=model_config.device,
         )
 
-    model.cuda()
+    device = base_model_context["device"]
+    model.to(device)
     model.eval()
     return model, base_model_context
 
@@ -68,6 +87,7 @@ def setup_and_build_model(
     shard_unsharded_model: bool = False,
     output_dir: str = "",
     opts: list | None = None,
+    device: str | torch.device | None = None,
     **ignored_kwargs,
 ) -> Tuple[nn.Module, BaseModelContext]:
     cudnn.benchmark = True
@@ -82,4 +102,4 @@ def setup_and_build_model(
     config = setup_config(setup_args, strict_cfg=False)
     model = build_model_for_eval(config, setup_args.pretrained_weights)
     autocast_dtype = get_autocast_dtype(config)
-    return model, BaseModelContext(autocast_dtype=autocast_dtype)
+    return model, BaseModelContext(autocast_dtype=autocast_dtype, device=resolve_device(device))

--- a/dinov3/eval/utils.py
+++ b/dinov3/eval/utils.py
@@ -163,7 +163,7 @@ def all_gather_and_flatten(tensor_rank):
     return tensor_all_ranks.flatten(end_dim=1)
 
 
-def extract_features(model, dataset, batch_size, num_workers, gather_on_cpu=False):
+def extract_features(model, dataset, batch_size, num_workers, gather_on_cpu=False, device=None):
     dataset_with_enumerated_targets = DatasetWithEnumeratedTargets(dataset)
     sample_count = len(dataset_with_enumerated_targets)
     data_loader = make_data_loader(
@@ -174,18 +174,23 @@ def extract_features(model, dataset, batch_size, num_workers, gather_on_cpu=Fals
         drop_last=False,
         shuffle=False,
     )
-    return extract_features_with_dataloader(model, data_loader, sample_count, gather_on_cpu)
+    return extract_features_with_dataloader(
+        model, data_loader, sample_count, gather_on_cpu=gather_on_cpu, device=device
+    )
 
 
 @torch.inference_mode()
-def extract_features_with_dataloader(model, data_loader, sample_count, gather_on_cpu=False):
-    gather_device = torch.device("cpu") if gather_on_cpu else torch.device("cuda")
+def extract_features_with_dataloader(model, data_loader, sample_count, gather_on_cpu=False, device=None):
+    from dinov3.eval.setup import resolve_device
+
+    device = resolve_device(device)
+    gather_device = torch.device("cpu") if gather_on_cpu else device
     metric_logger = MetricLogger(delimiter="  ")
     features, all_labels = None, None
     for samples, (index, labels_rank) in metric_logger.log_every(data_loader, 10):
-        samples = samples.cuda(non_blocking=True)
-        labels_rank = labels_rank.cuda(non_blocking=True)
-        index = index.cuda(non_blocking=True)
+        samples = samples.to(device, non_blocking=True)
+        labels_rank = labels_rank.to(device, non_blocking=True)
+        index = index.to(device, non_blocking=True)
         features_rank = model(samples).float()
 
         # init storage feature matrix
@@ -210,7 +215,6 @@ def extract_features_with_dataloader(model, data_loader, sample_count, gather_on
     logger.info(f"Labels Shape {all_labels.shape}")
 
     return features, all_labels
-
 
 def save_features_dict(features_dict: Dict[str, torch.Tensor], path: str) -> None:
     logger.info(f'saving features to "{path}"')

--- a/dinov3/hub/depthers.py
+++ b/dinov3/hub/depthers.py
@@ -100,6 +100,7 @@ def _make_dinov3_dpt_depther(
     depth_range: Optional[Tuple[float, float]] = None,
     check_hash: bool = False,
     autocast_dtype: torch.dtype = torch.float32,
+    device=None,
     **kwargs,
 ):
     backbone: torch.nn.Module = _BACKBONE_DICT[backbone_name](
@@ -111,6 +112,7 @@ def _make_dinov3_dpt_depther(
         backbone,
         config=_get_depther_config(backbone_name, depth_range),
         autocast_dtype=autocast_dtype,
+        device=device,
     )
 
     if pretrained:
@@ -133,6 +135,7 @@ def dinov3_vit7b16_dd(
     backbone_weights: BackboneWeights | str = BackboneWeights.LVD1689M,
     check_hash: bool = False,
     autocast_dtype: torch.dtype = torch.float32,
+    device=None,
     **kwargs,
 ):
     return _make_dinov3_dpt_depther(
@@ -142,6 +145,7 @@ def dinov3_vit7b16_dd(
         backbone_weights=backbone_weights,
         check_hash=check_hash,
         autocast_dtype=autocast_dtype,
+        device=device,
         **kwargs,
     )
 
@@ -175,6 +179,7 @@ def dinov3_vitl16_chmv2(
     backbone_weights: BackboneWeights | str = BackboneWeights.SAT493M,
     check_hash: bool = False,
     autocast_dtype: torch.dtype = torch.float32,
+    device=None,
     **kwargs,
 ):
     backbone: torch.nn.Module = dinov3_vitl16(pretrained=pretrained, weights=backbone_weights)
@@ -183,6 +188,7 @@ def dinov3_vitl16_chmv2(
         backbone,
         config=_get_chmv2_config(),
         autocast_dtype=autocast_dtype,
+        device=device,
     )
 
     if pretrained:


### PR DESCRIPTION
Allow selecting the eval/inference device via ModelConfig.device (and top-level device for depth/segmentation), instead of hardcoding .cuda() / autocast("cuda").
Default remains CUDA when available, otherwise CPU. Also thread the resolved device through feature extraction, linear/knn/logreg, depth, segmentation autocast, and hub depthers.